### PR TITLE
feat(about): feature Money Yu; fix(theme): HUD follows system theme

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "core:window:allow-set-position",
     "core:window:allow-start-dragging",
     "core:window:allow-center",
+    "core:window:allow-theme",
     "core:event:default",
     "core:event:allow-listen",
     "core:event:allow-emit",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
       "title": "About SayIt",
       "description": "Hold to speak, release to paste. SayIt is an open-source desktop speech-to-text tool, licensed under MIT.",
       "author": "Author:",
+      "originalAuthor": "Original author ·",
       "website": "Website",
       "sourceCode": "View Source Code",
       "reportIssue": "Report an Issue"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -9,6 +9,7 @@
       "title": "SayIt について",
       "description": "押して話し、離して貼り付け。SayIt はオープンソースのデスクトップ音声入力ツールで、MIT ライセンスで提供されています。",
       "author": "作者：",
+      "originalAuthor": "原作者 ·",
       "website": "個人サイト",
       "sourceCode": "ソースコードを見る",
       "reportIssue": "問題を報告"

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -9,6 +9,7 @@
       "title": "SayIt 정보",
       "description": "길게 눌러 말하고, 놓으면 붙여넣기. SayIt은 MIT 라이선스의 오픈소스 데스크톱 음성 텍스트 변환 도구입니다.",
       "author": "개발자:",
+      "originalAuthor": "원작자 ·",
       "website": "개인 웹사이트",
       "sourceCode": "소스 코드 보기",
       "reportIssue": "문제 신고"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -9,6 +9,7 @@
       "title": "关于 SayIt",
       "description": "按住说话，放开贴上。SayIt 是开源的桌面语音转文字工具，采用 MIT 授权。",
       "author": "作者：",
+      "originalAuthor": "原作者 ·",
       "website": "个人网站",
       "sourceCode": "查看源代码",
       "reportIssue": "反馈问题"

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -9,6 +9,7 @@
       "title": "關於 SayIt",
       "description": "按住說話，放開貼上。SayIt 是開源的桌面語音轉文字工具，採用 MIT 授權。",
       "author": "作者：",
+      "originalAuthor": "原作者 ·",
       "website": "個人網站",
       "sourceCode": "查看原始碼",
       "reportIssue": "回報問題"

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,4 +1,5 @@
 import { load } from "@tauri-apps/plugin-store";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { THEME_MODE_VALUES, type ThemeMode } from "../types/settings";
 
 const STORE_NAME = "settings.json";
@@ -11,6 +12,12 @@ let mediaQuery: MediaQueryList | null = null;
 let systemListener: ((event: MediaQueryListEvent) => void) | null = null;
 let activeMode: ThemeMode = DEFAULT_THEME_MODE;
 
+// OS 外觀以 Tauri 視窗主題 API 為權威來源（跨平台一致）；
+// 透明的 HUD WebView 在 Windows 下 CSS matchMedia 不一定反映 OS 外觀，
+// 故快取 Tauri 回報的 OS 主題，matchMedia 僅作為非 Tauri / null 時的 fallback。
+let osThemeDark: boolean | null = null;
+let osWatcherInit = false;
+
 export function isThemeMode(value: unknown): value is ThemeMode {
   return (
     typeof value === "string" &&
@@ -19,6 +26,7 @@ export function isThemeMode(value: unknown): value is ThemeMode {
 }
 
 function prefersDark(): boolean {
+  if (osThemeDark !== null) return osThemeDark;
   return (
     typeof window !== "undefined" &&
     typeof window.matchMedia === "function" &&
@@ -30,7 +38,35 @@ export function resolveTheme(mode: ThemeMode): "light" | "dark" {
   return mode === "system" ? (prefersDark() ? "dark" : "light") : mode;
 }
 
-// 只在 system 模式時掛系統偏好監聽，其餘模式移除，避免覆寫使用者選擇
+// 以 Tauri 視窗主題 API 取得權威 OS 外觀，快取供同步的 applyTheme 使用
+async function refreshOsTheme(): Promise<void> {
+  try {
+    const t = await getCurrentWindow().theme();
+    if (t === "dark") osThemeDark = true;
+    else if (t === "light") osThemeDark = false;
+    // null（如舊版 macOS）→ 維持原值，改用 matchMedia fallback
+  } catch {
+    // 非 Tauri 環境或無權限：維持 null，改用 matchMedia fallback
+  }
+}
+
+// 訂閱 OS 外觀變更（system 模式時即時重新套用），全程僅訂閱一次
+async function ensureOsThemeWatcher(): Promise<void> {
+  if (osWatcherInit) return;
+  osWatcherInit = true;
+  try {
+    await getCurrentWindow().onThemeChanged(({ payload }) => {
+      osThemeDark = payload === "dark";
+      if (activeMode === "system") {
+        document.documentElement.classList.toggle("dark", osThemeDark);
+      }
+    });
+  } catch {
+    osWatcherInit = false; // 失敗允許之後重試
+  }
+}
+
+// 只在 system 模式時掛系統偏好監聽（matchMedia fallback），其餘模式移除
 function ensureSystemListener(mode: ThemeMode): void {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
     return;
@@ -39,7 +75,8 @@ function ensureSystemListener(mode: ThemeMode): void {
     mediaQuery ??= window.matchMedia("(prefers-color-scheme: dark)");
     if (!systemListener) {
       systemListener = () => {
-        if (activeMode === "system") {
+        // Tauri onThemeChanged 為主；此處僅在無權威值時 fallback
+        if (activeMode === "system" && osThemeDark === null) {
           document.documentElement.classList.toggle("dark", prefersDark());
         }
       };
@@ -65,6 +102,10 @@ export function applyTheme(mode: ThemeMode): void {
 
 // mount 前盡早讀取持久化主題並套用，避免閃白
 export async function initThemeFromStore(): Promise<ThemeMode> {
+  // 先取得權威 OS 主題並訂閱變更，確保 system 模式在所有視窗解析一致
+  await refreshOsTheme();
+  void ensureOsThemeWatcher();
+
   let mode = DEFAULT_THEME_MODE;
   try {
     const store = await load(STORE_NAME);

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import { load } from "@tauri-apps/plugin-store";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { THEME_MODE_VALUES, type ThemeMode } from "../types/settings";
@@ -17,6 +18,7 @@ let activeMode: ThemeMode = DEFAULT_THEME_MODE;
 // 故快取 Tauri 回報的 OS 主題，matchMedia 僅作為非 Tauri / null 時的 fallback。
 let osThemeDark: boolean | null = null;
 let osWatcherInit = false;
+let unlistenOsThemeWatcher: (() => void) | null = null;
 
 export function isThemeMode(value: unknown): value is ThemeMode {
   return (
@@ -55,15 +57,26 @@ async function ensureOsThemeWatcher(): Promise<void> {
   if (osWatcherInit) return;
   osWatcherInit = true;
   try {
-    await getCurrentWindow().onThemeChanged(({ payload }) => {
-      osThemeDark = payload === "dark";
-      if (activeMode === "system") {
-        document.documentElement.classList.toggle("dark", osThemeDark);
-      }
-    });
+    unlistenOsThemeWatcher = await getCurrentWindow().onThemeChanged(
+      ({ payload }) => {
+        osThemeDark = payload === "dark";
+        if (activeMode === "system") {
+          document.documentElement.classList.toggle("dark", osThemeDark);
+        }
+      },
+    );
   } catch {
     osWatcherInit = false; // 失敗允許之後重試
   }
+}
+
+// Vite HMR：模組熱替換時解除舊訂閱，避免 dev 期間重複監聽
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    unlistenOsThemeWatcher?.();
+    unlistenOsThemeWatcher = null;
+    osWatcherInit = false;
+  });
 }
 
 // 只在 system 模式時掛系統偏好監聽（matchMedia fallback），其餘模式移除

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -107,6 +107,7 @@ import {
   Github,
   Globe,
   Instagram,
+  Linkedin,
   Lock,
   Mic,
   RefreshCw,
@@ -1434,32 +1435,39 @@ onBeforeUnmount(() => {
         <CardTitle class="text-base">{{ $t("settings.about.title") }}</CardTitle>
       </CardHeader>
       <CardContent class="space-y-4">
-        <div class="space-y-1">
-          <p class="text-sm text-muted-foreground">
-            {{ $t("settings.about.description") }}
-          </p>
-          <p class="text-sm text-muted-foreground">
-            {{ $t("settings.about.author") }}<a href="https://jackle.pro" target="_blank" rel="noopener noreferrer" class="font-medium text-foreground hover:text-primary transition-colors">Jackle Chen</a>
-          </p>
-        </div>
+        <p class="text-sm text-muted-foreground">
+          {{ $t("settings.about.description") }}
+        </p>
 
-        <div class="flex flex-wrap gap-x-4 gap-y-2">
-          <a href="https://jackle.pro" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
-            <Globe class="size-4" />
-            <span>{{ $t("settings.about.website") }}</span>
-          </a>
-          <a href="https://www.facebook.com/jackle45" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
-            <Facebook class="size-4" />
-            <span>Facebook</span>
-          </a>
-          <a href="https://www.instagram.com/jackle9527" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
-            <Instagram class="size-4" />
-            <span>Instagram</span>
-          </a>
-          <a href="https://www.threads.com/@jackle9527" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
-            <AtSign class="size-4" />
-            <span>Threads</span>
-          </a>
+        <!-- 作者：Money Yu（主要資訊，顯眼） -->
+        <div class="space-y-3">
+          <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <span class="text-sm text-muted-foreground">{{ $t("settings.about.author") }}</span>
+            <a href="https://github.com/lettucebo" target="_blank" rel="noopener noreferrer" class="text-base font-semibold text-foreground hover:text-primary transition-colors">Money Yu</a>
+          </div>
+
+          <div class="flex flex-wrap gap-x-4 gap-y-2">
+            <a href="https://github.com/lettucebo" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+              <Globe class="size-4" />
+              <span>{{ $t("settings.about.website") }}</span>
+            </a>
+            <a href="https://www.facebook.com/lettucebo" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+              <Facebook class="size-4" />
+              <span>Facebook</span>
+            </a>
+            <a href="https://www.instagram.com/moneyyu816/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+              <Instagram class="size-4" />
+              <span>Instagram</span>
+            </a>
+            <a href="https://www.threads.com/@moneyyu816" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+              <AtSign class="size-4" />
+              <span>Threads</span>
+            </a>
+            <a href="https://www.linkedin.com/in/abc12207/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+              <Linkedin class="size-4" />
+              <span>LinkedIn</span>
+            </a>
+          </div>
         </div>
 
         <Separator />
@@ -1474,6 +1482,12 @@ onBeforeUnmount(() => {
             <span>{{ $t("settings.about.reportIssue") }}</span>
           </a>
         </div>
+
+        <!-- 原作者（不起眼小字 credit） -->
+        <p class="text-xs text-muted-foreground/60">
+          {{ $t("settings.about.originalAuthor") }}
+          <a href="https://jackle.pro" target="_blank" rel="noopener noreferrer" class="underline-offset-2 hover:text-muted-foreground hover:underline">Jackle Chen</a>
+        </p>
       </CardContent>
     </Card>
 

--- a/tests/unit/theme.test.ts
+++ b/tests/unit/theme.test.ts
@@ -15,6 +15,19 @@ vi.mock("@tauri-apps/plugin-store", () => ({
   })),
 }));
 
+// Tauri 視窗主題 API mock：osTheme 為權威 OS 外觀（null → 改用 matchMedia fallback）
+const tauriWindow = vi.hoisted(() => ({
+  osTheme: null as "light" | "dark" | null,
+  onThemeChanged: vi.fn(async () => () => {}),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    theme: vi.fn(async () => tauriWindow.osTheme),
+    onThemeChanged: tauriWindow.onThemeChanged,
+  }),
+}));
+
 function stubMatchMedia(dark: boolean) {
   vi.stubGlobal(
     "matchMedia",
@@ -32,6 +45,8 @@ describe("theme lib", () => {
     mockStoreGet.mockClear();
     mockStoreSet.mockClear();
     mockStoreSave.mockClear();
+    tauriWindow.osTheme = null;
+    tauriWindow.onThemeChanged.mockClear();
     document.documentElement.classList.remove("dark");
     vi.resetModules();
   });
@@ -87,5 +102,23 @@ describe("theme lib", () => {
     const mode = await initThemeFromStore();
     expect(mode).toBe("light");
     expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("[P0] system 模式以 Tauri 視窗主題為權威（matchMedia 不準時仍正確）", async () => {
+    // matchMedia 回報淺色（模擬 HUD WebView 不準），但 OS 實為深色
+    stubMatchMedia(false);
+    tauriWindow.osTheme = "dark";
+    mockStoreData.set("themeMode", "system");
+    const { initThemeFromStore } = await import("../../src/lib/theme");
+    await initThemeFromStore();
+    // 應以 Tauri 權威值（dark）為準
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("[P1] initThemeFromStore 應訂閱 OS 主題變更（onThemeChanged）", async () => {
+    stubMatchMedia(false);
+    const { initThemeFromStore } = await import("../../src/lib/theme");
+    await initThemeFromStore();
+    expect(tauriWindow.onThemeChanged).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## 變更摘要

兩項變更：

### 1. 關於 SayIt 卡片改主打 Money Yu
- 作者改為 **Money Yu**（顯眼主位，連結 github.com/lettucebo）
- 社群連結：個人網站、Facebook、Instagram、Threads、LinkedIn
- 原始碼／回報問題維持指向 `lettucebo/SayIt`
- 原作者 Jackle Chen 縮為底部 `text-xs` 不起眼小字（保留 jackle.pro 連結）
- 5 語系新增 `settings.about.originalAuthor`

### 2. 修正 HUD 不跟隨系統主題
- **根因**：`system` 模式以 CSS `matchMedia('(prefers-color-scheme: dark)')` 在各視窗各自解析；透明的 HUD WebView（Windows WebView2）不一定反映 OS 外觀，導致切「跟隨系統」時 Dashboard 正確、HUD 仍停在淺色。
- **修法**：改以 Tauri 視窗主題 API `getCurrentWindow().theme()` 取得權威 OS 外觀並快取，`onThemeChanged` 即時跟隨；`matchMedia` 保留為非 Tauri/null 時 fallback。新增 capability `core:window:allow-theme`。

## 影響模組

`src/lib/theme.ts`、`src-tauri/capabilities/default.json`、`src/views/SettingsView.vue`、`src/i18n/locales/*`、`tests/unit/theme.test.ts`

無 SQL migration。

## 待人工驗證

`pnpm tauri dev` 雙視窗：切換 淺色 → 跟隨系統，確認 HUD 與 Dashboard 同步跟隨 OS（本機 MSVC 缺 msvcrt.lib，須 CI/另機驗）。
