### PR TITLE
feat(history): revive per-record retry (re-transcribe / re-enhance)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -335,7 +335,13 @@
     "loadingMore": "Loading more...",
     "playRecording": "Play recording",
     "noRecordingFile": "Recording file not available",
-    "failedBadge": "Failed"
+    "failedBadge": "Failed",
+    "retranscribe": "Re-transcribe",
+    "reEnhance": "Re-enhance",
+    "retranscribing": "Re-transcribing…",
+    "reEnhancing": "Re-enhancing…",
+    "retranscribeFailed": "Re-transcription failed, please try again",
+    "reEnhanceFailed": "Re-enhancement failed, please try again"
   },
   "dictionary": {
     "termCount": "{count} terms",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -335,7 +335,13 @@
     "loadingMore": "さらに読み込み中...",
     "playRecording": "録音を再生",
     "noRecordingFile": "録音ファイルがありません",
-    "failedBadge": "認識失敗"
+    "failedBadge": "認識失敗",
+    "retranscribe": "再認識",
+    "reEnhance": "再整形",
+    "retranscribing": "再認識中…",
+    "reEnhancing": "再整形中…",
+    "retranscribeFailed": "再認識に失敗しました。後でもう一度お試しください",
+    "reEnhanceFailed": "再整形に失敗しました。後でもう一度お試しください"
   },
   "dictionary": {
     "termCount": "{count} 語",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -335,7 +335,13 @@
     "loadingMore": "더 불러오는 중...",
     "playRecording": "녹음 재생",
     "noRecordingFile": "녹음 파일이 없습니다",
-    "failedBadge": "인식 실패"
+    "failedBadge": "인식 실패",
+    "retranscribe": "다시 인식",
+    "reEnhance": "다시 정리",
+    "retranscribing": "다시 인식 중…",
+    "reEnhancing": "다시 정리 중…",
+    "retranscribeFailed": "다시 인식하지 못했습니다. 잠시 후 다시 시도하세요",
+    "reEnhanceFailed": "다시 정리하지 못했습니다. 잠시 후 다시 시도하세요"
   },
   "dictionary": {
     "termCount": "{count} 단어",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -335,7 +335,13 @@
     "loadingMore": "加载更多...",
     "playRecording": "播放录音",
     "noRecordingFile": "录音文件不存在",
-    "failedBadge": "识别失败"
+    "failedBadge": "识别失败",
+    "retranscribe": "重新识别",
+    "reEnhance": "重新整理",
+    "retranscribing": "重新识别中…",
+    "reEnhancing": "重新整理中…",
+    "retranscribeFailed": "重新识别失败，请稍后再试",
+    "reEnhanceFailed": "重新整理失败，请稍后再试"
   },
   "dictionary": {
     "termCount": "{count} 词汇",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -335,7 +335,13 @@
     "loadingMore": "載入更多...",
     "playRecording": "播放錄音",
     "noRecordingFile": "錄音檔案不存在",
-    "failedBadge": "辨識失敗"
+    "failedBadge": "辨識失敗",
+    "retranscribe": "重新辨識",
+    "reEnhance": "重新整理",
+    "retranscribing": "重新辨識中…",
+    "reEnhancing": "重新整理中…",
+    "retranscribeFailed": "重新辨識失敗，請稍後再試",
+    "reEnhanceFailed": "重新整理失敗，請稍後再試"
   },
   "dictionary": {
     "termCount": "{count} 詞彙",

--- a/src/lib/enhancer.ts
+++ b/src/lib/enhancer.ts
@@ -13,8 +13,10 @@ import {
 import { getMinimalPromptForLocale } from "../i18n/prompts";
 import type { SupportedLocale } from "../i18n/languageConfig";
 import i18n from "../i18n";
+import { detectEnhancementAnomaly } from "./hallucinationDetector";
 
 const MAX_VOCABULARY_TERMS = 50;
+const DEFAULT_ENHANCEMENT_RETRY_COUNT = 3;
 
 export class EnhancerApiError extends Error {
   constructor(
@@ -175,4 +177,50 @@ export async function enhanceText(
 
   const enhancedContent = stripReasoningTags(result.text);
   return { text: enhancedContent || rawText, usage };
+}
+
+export interface EnhanceWithGuardResult {
+  text: string;
+  usage: ChatUsageData | null;
+  /** true 表示重試後仍偵測到長度爆炸異常，text 已 fallback 回 rawText。 */
+  wasAnomalous: boolean;
+}
+
+/**
+ * enhanceText 外加「增強後長度爆炸」防護：偵測到異常時最多重試 maxRetries 次，
+ * 仍異常則 fallback 回 rawText 並標記 wasAnomalous=true。
+ * 目前由歷史紀錄重新整理使用；邏輯與 useVoiceFlowStore 即時流程的 inline 迴圈一致，未來可收斂共用。
+ */
+export async function enhanceWithAnomalyGuard(
+  rawText: string,
+  apiKey: string,
+  options?: EnhanceOptions,
+  maxRetries = DEFAULT_ENHANCEMENT_RETRY_COUNT,
+): Promise<EnhanceWithGuardResult> {
+  let enhanceResult = await enhanceText(rawText, apiKey, options);
+
+  let retryCount = 0;
+  while (
+    retryCount < maxRetries &&
+    detectEnhancementAnomaly({ rawText, enhancedText: enhanceResult.text })
+      .isAnomaly
+  ) {
+    retryCount++;
+    enhanceResult = await enhanceText(rawText, apiKey, options);
+  }
+
+  const finalAnomaly = detectEnhancementAnomaly({
+    rawText,
+    enhancedText: enhanceResult.text,
+  });
+
+  if (finalAnomaly.isAnomaly) {
+    return { text: rawText, usage: enhanceResult.usage, wasAnomalous: true };
+  }
+
+  return {
+    text: enhanceResult.text,
+    usage: enhanceResult.usage,
+    wasAnomalous: false,
+  };
 }

--- a/src/stores/useHistoryStore.ts
+++ b/src/stores/useHistoryStore.ts
@@ -6,8 +6,10 @@ import type {
   DailyQuotaUsage,
   ApiUsageRecord,
   DailyUsageTrend,
+  ChatUsageData,
 } from "../types/transcription";
 import type { TriggerMode } from "../types";
+import type { TranscriptionResult } from "../types/audio";
 import type { TranscriptionCompletedPayload } from "../types/events";
 import { invoke } from "@tauri-apps/api/core";
 import { getDatabase } from "../lib/database";
@@ -15,9 +17,27 @@ import { buildDailyUsageSeries } from "../lib/usageTrend";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { captureError } from "../lib/sentry";
 import {
+  calculateChatCostCeiling,
+  calculateWhisperCostCeiling,
+} from "../lib/apiPricing";
+import {
+  enhanceWithAnomalyGuard,
+  type EnhanceWithGuardResult,
+} from "../lib/enhancer";
+import { detectHallucination } from "../lib/hallucinationDetector";
+import { useSettingsStore } from "./useSettingsStore";
+import { useVocabularyStore } from "./useVocabularyStore";
+import {
   emitToWindow,
   TRANSCRIPTION_COMPLETED,
 } from "../composables/useTauriEvents";
+
+/** 歷史紀錄重試（重新辨識／重新整理）的結果；errorKey 為 i18n key，供 UI 顯示。 */
+export interface HistoryRetryResult {
+  ok: boolean;
+  record?: TranscriptionRecord;
+  errorKey?: string;
+}
 
 const PAGE_SIZE = 20;
 const USAGE_TREND_DAYS = 14;
@@ -148,6 +168,26 @@ const UPDATE_ON_RETRY_SUCCESS_SQL = `
       was_enhanced = $5,
       char_count = $6
   WHERE id = $7
+`;
+
+const UPDATE_ON_RETRANSCRIBE_SQL = `
+  UPDATE transcriptions
+  SET status = 'success',
+      raw_text = $1,
+      processed_text = NULL,
+      transcription_duration_ms = $2,
+      enhancement_duration_ms = NULL,
+      was_enhanced = 0,
+      char_count = $3
+  WHERE id = $4
+`;
+
+const UPDATE_ON_REENHANCE_SQL = `
+  UPDATE transcriptions
+  SET processed_text = $1,
+      was_enhanced = 1,
+      enhancement_duration_ms = $2
+  WHERE id = $3
 `;
 
 const DELETE_API_USAGE_BY_TRANSCRIPTION_SQL = `
@@ -565,6 +605,234 @@ export const useHistoryStore = defineStore("history", () => {
     return deletedCount;
   }
 
+  function applyLocalRecordUpdate(
+    id: string,
+    patch: Partial<TranscriptionRecord>,
+  ): TranscriptionRecord | undefined {
+    const target = transcriptionList.value.find((r) => r.id === id);
+    if (!target) return undefined;
+    const updated: TranscriptionRecord = { ...target, ...patch };
+    transcriptionList.value = transcriptionList.value.map((r) =>
+      r.id === id ? updated : r,
+    );
+    return updated;
+  }
+
+  function recordWhisperUsage(
+    transcriptionId: string,
+    audioDurationMs: number,
+    model: string,
+  ): void {
+    void addApiUsage({
+      id: crypto.randomUUID(),
+      transcriptionId,
+      apiType: "whisper",
+      model,
+      promptTokens: null,
+      completionTokens: null,
+      totalTokens: null,
+      promptTimeMs: null,
+      completionTimeMs: null,
+      totalTimeMs: null,
+      audioDurationMs,
+      estimatedCostCeiling: calculateWhisperCostCeiling(audioDurationMs, model),
+    }).catch((err) =>
+      captureError(err, { source: "history", step: "retranscribe-usage" }),
+    );
+  }
+
+  function recordChatUsage(
+    transcriptionId: string,
+    usage: ChatUsageData | null,
+    model: string,
+  ): void {
+    if (!usage) return;
+    void addApiUsage({
+      id: crypto.randomUUID(),
+      transcriptionId,
+      apiType: "chat",
+      model,
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.completionTokens,
+      totalTokens: usage.totalTokens,
+      promptTimeMs: usage.promptTimeMs ?? null,
+      completionTimeMs: usage.completionTimeMs ?? null,
+      totalTimeMs: usage.totalTimeMs ?? null,
+      audioDurationMs: null,
+      estimatedCostCeiling: calculateChatCostCeiling(usage.totalTokens, model),
+    }).catch((err) =>
+      captureError(err, { source: "history", step: "reenhance-usage" }),
+    );
+  }
+
+  /**
+   * 歷史紀錄「重新辨識」：以保存的錄音檔重送轉錄。成功即把該筆 failed → success
+   * 並清空整理結果（等待使用者另行「重新整理」）。只更新該筆，不貼上、不碰 HUD 狀態機。
+   */
+  async function retranscribeRecord(
+    record: TranscriptionRecord,
+  ): Promise<HistoryRetryResult> {
+    if (!record.audioFilePath) {
+      return { ok: false, errorKey: "history.noRecordingFile" };
+    }
+
+    const settingsStore = useSettingsStore();
+    const vocabularyStore = useVocabularyStore();
+
+    if (
+      settingsStore.whisperProviderId === "groq" &&
+      !settingsStore.getApiKey()
+    ) {
+      await settingsStore.refreshApiKey();
+    }
+
+    const whisperCfg = await settingsStore.getWhisperRequestConfig();
+    if (!whisperCfg.apiKey) {
+      return { ok: false, errorKey: "errors.apiKeyMissing" };
+    }
+
+    const whisperTermList = await vocabularyStore.getTopTermListByWeight(50);
+    const model = settingsStore.selectedWhisperModelId;
+
+    let result: TranscriptionResult;
+    try {
+      result = await invoke<TranscriptionResult>("retranscribe_from_file", {
+        filePath: record.audioFilePath,
+        apiKey: whisperCfg.apiKey,
+        vocabularyTermList:
+          whisperTermList.length > 0 ? whisperTermList : null,
+        modelId: model,
+        language: settingsStore.getWhisperLanguageCode(),
+        provider: whisperCfg.provider,
+        endpoint: whisperCfg.endpoint ?? null,
+        deployment: whisperCfg.deployment ?? null,
+        apiVersion: whisperCfg.apiVersion ?? null,
+        authMode: whisperCfg.authMode ?? null,
+      });
+    } catch (err) {
+      captureError(err, { source: "history", step: "retranscribe-invoke" });
+      return { ok: false, errorKey: "history.retranscribeFailed" };
+    }
+
+    // HTTP 成功即計費（不論轉錄內容）→ 記錄 whisper 用量
+    recordWhisperUsage(record.id, record.recordingDurationMs, model);
+
+    // 空轉錄或幻覺 → 保留 failed、不覆寫原文
+    const isEmpty = !result.rawText || !result.rawText.trim();
+    // 時長未知/非正時跳過語速異常層（無法判斷語速），仍保留能量/NSP 偵測
+    const recordingDurationForDetection =
+      record.recordingDurationMs > 0
+        ? record.recordingDurationMs
+        : Number.MAX_SAFE_INTEGER;
+    const hallucination = detectHallucination({
+      rawText: result.rawText,
+      recordingDurationMs: recordingDurationForDetection,
+      peakEnergyLevel: result.peakEnergyLevel,
+      rmsEnergyLevel: result.rmsEnergyLevel,
+      noSpeechProbability: result.noSpeechProbability,
+    });
+    if (isEmpty || hallucination.isHallucination) {
+      return { ok: false, errorKey: "history.retranscribeFailed" };
+    }
+
+    const charCount = result.rawText.length;
+    const transcriptionDurationMs = Math.round(result.transcriptionDurationMs);
+
+    const db = getDatabase();
+    const res = await db.execute(UPDATE_ON_RETRANSCRIBE_SQL, [
+      result.rawText,
+      transcriptionDurationMs,
+      charCount,
+      record.id,
+    ]);
+    if (!res?.rowsAffected) {
+      return { ok: false, errorKey: "history.retranscribeFailed" };
+    }
+
+    const updated = applyLocalRecordUpdate(record.id, {
+      status: "success",
+      rawText: result.rawText,
+      processedText: null,
+      wasEnhanced: false,
+      transcriptionDurationMs,
+      enhancementDurationMs: null,
+      charCount,
+    });
+    return { ok: true, record: updated };
+  }
+
+  /**
+   * 歷史紀錄「重新整理」：用既有原文重跑 AI 校對，套用與即時流程相同的長度爆炸防護。
+   * 成功則寫入 processed_text 並標記 was_enhanced。只更新該筆，不貼上、不碰 HUD 狀態機。
+   */
+  async function reEnhanceRecord(
+    record: TranscriptionRecord,
+  ): Promise<HistoryRetryResult> {
+    if (!record.rawText.trim()) {
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    const settingsStore = useSettingsStore();
+    const vocabularyStore = useVocabularyStore();
+
+    await settingsStore.refreshLlmApiKey();
+    const llmCfg = await settingsStore.getLlmRequestConfig();
+    if (!llmCfg.apiKey) {
+      return { ok: false, errorKey: "errors.apiKeyMissing" };
+    }
+
+    const termList = await vocabularyStore.getTopTermListByWeight(50);
+    const startTime = performance.now();
+
+    let enhanceResult: EnhanceWithGuardResult;
+    try {
+      enhanceResult = await enhanceWithAnomalyGuard(
+        record.rawText,
+        llmCfg.apiKey,
+        {
+          systemPrompt: settingsStore.getAiPrompt(),
+          vocabularyTermList: termList.length > 0 ? termList : undefined,
+          modelId: llmCfg.modelId,
+          provider: llmCfg.provider,
+          azure: llmCfg.azure,
+        },
+      );
+    } catch (err) {
+      captureError(err, { source: "history", step: "reenhance" });
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    const enhancementDurationMs = Math.round(performance.now() - startTime);
+
+    // API 已呼叫（即使 anomaly fallback）→ 記錄 chat 用量
+    recordChatUsage(
+      record.id,
+      enhanceResult.usage,
+      settingsStore.getEffectiveChatModel(),
+    );
+
+    if (enhanceResult.wasAnomalous) {
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    const db = getDatabase();
+    const res = await db.execute(UPDATE_ON_REENHANCE_SQL, [
+      enhanceResult.text,
+      enhancementDurationMs,
+      record.id,
+    ]);
+    if (!res?.rowsAffected) {
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    const updated = applyLocalRecordUpdate(record.id, {
+      processedText: enhanceResult.text,
+      wasEnhanced: true,
+      enhancementDurationMs,
+    });
+    return { ok: true, record: updated };
+  }
+
   return {
     transcriptionList,
     isLoading,
@@ -589,5 +857,7 @@ export const useHistoryStore = defineStore("history", () => {
     clearAudioFilePathByIdList,
     deleteTranscription,
     deleteAllRecordingFiles,
+    retranscribeRecord,
+    reEnhanceRecord,
   };
 });

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -19,7 +19,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, ChevronDown, Copy, Check, Trash2, Play, Pause } from "lucide-vue-next";
+import { Search, ChevronDown, Copy, Check, Trash2, Play, Pause, RefreshCw, Sparkles, Loader2 } from "lucide-vue-next";
 import { captureError } from "../lib/sentry";
 
 const historyStore = useHistoryStore();
@@ -30,6 +30,9 @@ const copiedRecordId = ref<string | null>(null);
 const copiedRawRecordId = ref<string | null>(null);
 const sentinelRef = ref<HTMLElement | null>(null);
 const playingRecordId = ref<string | null>(null);
+const retryingId = ref<string | null>(null);
+const retryingAction = ref<"transcribe" | "enhance" | null>(null);
+const retryError = ref<{ id: string; key: string } | null>(null);
 let currentAudio: HTMLAudioElement | null = null;
 let currentBlobUrl: string | null = null;
 
@@ -145,6 +148,50 @@ async function handlePlayRecording(record: TranscriptionRecord) {
     cleanupAudio();
     playingRecordId.value = null;
     captureError(err, { source: "history-view", step: "play-recording" });
+  }
+}
+
+async function handleRetranscribe(record: TranscriptionRecord) {
+  if (retryingId.value) return;
+  retryingId.value = record.id;
+  retryingAction.value = "transcribe";
+  retryError.value = null;
+  try {
+    const result = await historyStore.retranscribeRecord(record);
+    if (!result.ok) {
+      retryError.value = {
+        id: record.id,
+        key: result.errorKey ?? "history.retranscribeFailed",
+      };
+    }
+  } catch (err) {
+    captureError(err, { source: "history-view", step: "retranscribe" });
+    retryError.value = { id: record.id, key: "history.retranscribeFailed" };
+  } finally {
+    retryingId.value = null;
+    retryingAction.value = null;
+  }
+}
+
+async function handleReEnhance(record: TranscriptionRecord) {
+  if (retryingId.value) return;
+  retryingId.value = record.id;
+  retryingAction.value = "enhance";
+  retryError.value = null;
+  try {
+    const result = await historyStore.reEnhanceRecord(record);
+    if (!result.ok) {
+      retryError.value = {
+        id: record.id,
+        key: result.errorKey ?? "history.reEnhanceFailed",
+      };
+    }
+  } catch (err) {
+    captureError(err, { source: "history-view", step: "reenhance" });
+    retryError.value = { id: record.id, key: "history.reEnhanceFailed" };
+  } finally {
+    retryingId.value = null;
+    retryingAction.value = null;
   }
 }
 
@@ -285,6 +332,30 @@ onBeforeUnmount(() => {
                     <Check v-if="copiedRecordId === record.id" class="h-3.5 w-3.5 text-green-400" />
                     <Copy v-else class="h-3.5 w-3.5" />
                   </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7"
+                    data-testid="retranscribe-button"
+                    :disabled="!record.audioFilePath || retryingId !== null"
+                    :title="retryingId === record.id && retryingAction === 'transcribe' ? $t('history.retranscribing') : (record.audioFilePath ? $t('history.retranscribe') : $t('history.noRecordingFile'))"
+                    @click.stop="handleRetranscribe(record)"
+                  >
+                    <Loader2 v-if="retryingId === record.id && retryingAction === 'transcribe'" class="h-3.5 w-3.5 animate-spin" />
+                    <RefreshCw v-else class="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7"
+                    data-testid="reenhance-button"
+                    :disabled="!record.rawText.trim() || retryingId !== null"
+                    :title="retryingId === record.id && retryingAction === 'enhance' ? $t('history.reEnhancing') : $t('history.reEnhance')"
+                    @click.stop="handleReEnhance(record)"
+                  >
+                    <Loader2 v-if="retryingId === record.id && retryingAction === 'enhance'" class="h-3.5 w-3.5 animate-spin" />
+                    <Sparkles v-else class="h-3.5 w-3.5" />
+                  </Button>
                   <ChevronDown
                     class="h-3.5 w-3.5 text-muted-foreground transition-transform"
                     :class="{ 'rotate-180': expandedRecordId === record.id }"
@@ -295,6 +366,14 @@ onBeforeUnmount(() => {
                 {{ truncateText(getDisplayText(record)) }}
               </p>
             </div>
+            <!-- 重試錯誤訊息（每筆常駐顯示）-->
+            <p
+              v-if="retryError && retryError.id === record.id"
+              class="px-5 pb-2 text-xs text-destructive"
+              data-testid="retry-error"
+            >
+              {{ $t(retryError.key) }}
+            </p>
 
             <!-- 展開詳細 -->
             <div

--- a/tests/component/HistoryView.test.ts
+++ b/tests/component/HistoryView.test.ts
@@ -1,0 +1,183 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "../../src/i18n";
+import HistoryView from "../../src/views/HistoryView.vue";
+import type { TranscriptionRecord } from "../../src/types/transcription";
+
+vi.mock("../../src/composables/useTauriEvents", () => ({
+  listenToEvent: vi.fn().mockResolvedValue(vi.fn()),
+  TRANSCRIPTION_COMPLETED: "transcription:completed",
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+vi.mock("../../src/lib/sentry", () => ({ captureError: vi.fn() }));
+
+let historyState: Record<string, unknown>;
+
+vi.mock("../../src/stores/useHistoryStore", () => ({
+  useHistoryStore: () => historyState,
+}));
+
+function createRecord(
+  overrides: Partial<TranscriptionRecord> = {},
+): TranscriptionRecord {
+  return {
+    id: "rec-1",
+    timestamp: 1700000000000,
+    rawText: "原始文字內容",
+    processedText: null,
+    recordingDurationMs: 3000,
+    transcriptionDurationMs: 280,
+    enhancementDurationMs: null,
+    charCount: 6,
+    triggerMode: "hold",
+    wasEnhanced: false,
+    wasModified: null,
+    createdAt: "",
+    audioFilePath: "C:/rec/rec-1.wav",
+    status: "success",
+    isEditMode: false,
+    editSourceText: null,
+    ...overrides,
+  };
+}
+
+function makeHistory(records: TranscriptionRecord[]): Record<string, unknown> {
+  return {
+    transcriptionList: records,
+    isLoading: false,
+    hasMore: false,
+    searchQuery: "",
+    resetAndFetch: vi.fn().mockResolvedValue(undefined),
+    loadMore: vi.fn().mockResolvedValue(undefined),
+    retranscribeRecord: vi.fn().mockResolvedValue({ ok: true }),
+    reEnhanceRecord: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+const ButtonStub = {
+  name: "Button",
+  inheritAttrs: false,
+  template: '<button v-bind="$attrs"><slot /></button>',
+};
+
+async function mountExpanded(record: TranscriptionRecord) {
+  historyState = makeHistory([record]);
+  const wrapper = mount(HistoryView, {
+    global: {
+      plugins: [i18n],
+      stubs: { Button: ButtonStub },
+    },
+  });
+  // 展開該紀錄，重試按鈕位於展開詳細區
+  await wrapper.find(".cursor-pointer").trigger("click");
+  await wrapper.vm.$nextTick();
+  return wrapper;
+}
+
+describe("HistoryView 重試按鈕", () => {
+  beforeEach(() => {
+    class IOStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("IntersectionObserver", IOStub);
+  });
+
+  it("[P1] 每筆紀錄都顯示兩顆重試按鈕（含已整理的成功紀錄）", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({
+        status: "success",
+        wasEnhanced: true,
+        processedText: "整理後文字",
+        rawText: "原文",
+        audioFilePath: "C:/rec/rec-1.wav",
+      }),
+    );
+    expect(wrapper.find('[data-testid="retranscribe-button"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="reenhance-button"]').exists()).toBe(true);
+  });
+
+  it("[P1] 有錄音檔與原文 → 兩顆皆可用（未 disabled）", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({ audioFilePath: "C:/rec/rec-1.wav", rawText: "有原文" }),
+    );
+    expect(
+      wrapper.find('[data-testid="retranscribe-button"]').attributes("disabled"),
+    ).toBeUndefined();
+    expect(
+      wrapper.find('[data-testid="reenhance-button"]').attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("[P1] 無錄音檔 → 重新辨識 disabled、重新整理仍可用", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({ audioFilePath: null, rawText: "有原文" }),
+    );
+    expect(
+      wrapper.find('[data-testid="retranscribe-button"]').attributes("disabled"),
+    ).toBeDefined();
+    expect(
+      wrapper.find('[data-testid="reenhance-button"]').attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("[P1] 空原文 → 重新整理 disabled、重新辨識仍可用", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({
+        status: "failed",
+        audioFilePath: "C:/rec/rec-1.wav",
+        rawText: "   ",
+      }),
+    );
+    expect(
+      wrapper.find('[data-testid="reenhance-button"]').attributes("disabled"),
+    ).toBeDefined();
+    expect(
+      wrapper.find('[data-testid="retranscribe-button"]').attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("[P1] 點擊重新辨識會呼叫 store.retranscribeRecord", async () => {
+    const record = createRecord({ audioFilePath: "C:/rec/rec-1.wav" });
+    const wrapper = await mountExpanded(record);
+    await wrapper.find('[data-testid="retranscribe-button"]').trigger("click");
+    expect(historyState.retranscribeRecord).toHaveBeenCalledTimes(1);
+    expect(historyState.retranscribeRecord).toHaveBeenCalledWith(record);
+  });
+
+  it("[P1] 點擊重新整理會呼叫 store.reEnhanceRecord", async () => {
+    const record = createRecord({ rawText: "可整理的原文" });
+    const wrapper = await mountExpanded(record);
+    await wrapper.find('[data-testid="reenhance-button"]').trigger("click");
+    expect(historyState.reEnhanceRecord).toHaveBeenCalledTimes(1);
+    expect(historyState.reEnhanceRecord).toHaveBeenCalledWith(record);
+  });
+
+  it("[P2] 重試進行中，其他紀錄的重試按鈕應 disabled（全域鎖）", async () => {
+    let resolveRetry: (v: { ok: boolean }) => void = () => {};
+    const recordA = createRecord({ id: "rec-A", audioFilePath: "C:/a.wav" });
+    const recordB = createRecord({ id: "rec-B", audioFilePath: "C:/b.wav" });
+    historyState = makeHistory([recordA, recordB]);
+    historyState.retranscribeRecord = vi.fn(
+      () => new Promise<{ ok: boolean }>((r) => (resolveRetry = r)),
+    );
+    const wrapper = mount(HistoryView, {
+      global: { plugins: [i18n], stubs: { Button: ButtonStub } },
+    });
+    // 重試按鈕常駐於摘要列，每筆一顆
+    const buttons = wrapper.findAll('[data-testid="retranscribe-button"]');
+    expect(buttons.length).toBe(2);
+    // 觸發 A 的重試（pending）
+    await buttons[0].trigger("click");
+    await wrapper.vm.$nextTick();
+    // B 的重試按鈕應因全域鎖 disabled
+    const after = wrapper.findAll('[data-testid="retranscribe-button"]');
+    expect(after[1].attributes("disabled")).toBeDefined();
+    resolveRetry({ ok: true });
+  });
+});

--- a/tests/unit/enhancer.test.ts
+++ b/tests/unit/enhancer.test.ts
@@ -521,3 +521,54 @@ describe("enhancer.ts", () => {
     });
   });
 });
+
+describe("enhanceWithAnomalyGuard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("[P1] 正常整理（無長度爆炸）→ wasAnomalous=false 並採用整理結果", async () => {
+    mockFetch.mockResolvedValue(
+      createSuccessResponse("這是一段整理後的書面語文字。"),
+    );
+    const { enhanceWithAnomalyGuard } = await import("../../src/lib/enhancer");
+    const result = await enhanceWithAnomalyGuard(
+      "這是一段整理後的書面語文字",
+      TEST_API_KEY,
+    );
+    expect(result.wasAnomalous).toBe(false);
+    expect(result.text).toBe("這是一段整理後的書面語文字。");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("[P1] 持續長度爆炸 → 重試後 fallback 回 rawText 並標記 wasAnomalous", async () => {
+    mockFetch.mockResolvedValue(createSuccessResponse("爆".repeat(50)));
+    const { enhanceWithAnomalyGuard } = await import("../../src/lib/enhancer");
+    const result = await enhanceWithAnomalyGuard("短文", TEST_API_KEY, undefined, 3);
+    expect(result.wasAnomalous).toBe(true);
+    expect(result.text).toBe("短文");
+    // 1 次初始 + 3 次重試
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("[P1] 首次長度爆炸、重試後正常 → 採用正常結果", async () => {
+    mockFetch
+      .mockResolvedValueOnce(createSuccessResponse("爆".repeat(50)))
+      .mockResolvedValueOnce(createSuccessResponse("正常整理後的文字"));
+    const { enhanceWithAnomalyGuard } = await import("../../src/lib/enhancer");
+    const result = await enhanceWithAnomalyGuard(
+      "一段原始口語文字",
+      TEST_API_KEY,
+      undefined,
+      3,
+    );
+    expect(result.wasAnomalous).toBe(false);
+    expect(result.text).toBe("正常整理後的文字");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/use-history-retry.test.ts
+++ b/tests/unit/use-history-retry.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import type { TranscriptionRecord } from "../../src/types/transcription";
+
+const h = vi.hoisted(() => {
+  const mockDbExecute = vi.fn();
+  const mockInvoke = vi.fn();
+  const mockEnhanceGuard = vi.fn();
+  const mockGetTopTerms = vi.fn();
+  const settingsStub = {
+    whisperProviderId: "groq",
+    getApiKey: () => "whisper-key",
+    refreshApiKey: vi.fn(),
+    getWhisperRequestConfig: vi.fn(),
+    selectedWhisperModelId: "whisper-large-v3-turbo",
+    getWhisperLanguageCode: () => "zh",
+    refreshLlmApiKey: vi.fn(),
+    getLlmRequestConfig: vi.fn(),
+    getAiPrompt: () => "prompt",
+    getEffectiveChatModel: () => "llama-3.3-70b-versatile",
+  };
+  return {
+    mockDbExecute,
+    mockInvoke,
+    mockEnhanceGuard,
+    mockGetTopTerms,
+    settingsStub,
+  };
+});
+
+vi.mock("../../src/lib/database", () => ({
+  getDatabase: () => ({ execute: h.mockDbExecute, select: vi.fn() }),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: h.mockInvoke }));
+vi.mock("../../src/composables/useTauriEvents", () => ({
+  emitToWindow: vi.fn().mockResolvedValue(undefined),
+  TRANSCRIPTION_COMPLETED: "transcription:completed",
+}));
+vi.mock("../../src/lib/sentry", () => ({ captureError: vi.fn() }));
+vi.mock("../../src/lib/enhancer", () => ({
+  enhanceWithAnomalyGuard: h.mockEnhanceGuard,
+}));
+vi.mock("../../src/stores/useSettingsStore", () => ({
+  useSettingsStore: () => h.settingsStub,
+}));
+vi.mock("../../src/stores/useVocabularyStore", () => ({
+  useVocabularyStore: () => ({ getTopTermListByWeight: h.mockGetTopTerms }),
+}));
+
+import { useHistoryStore } from "../../src/stores/useHistoryStore";
+
+function createRecord(
+  overrides: Partial<TranscriptionRecord> = {},
+): TranscriptionRecord {
+  return {
+    id: "rec-1",
+    timestamp: 1700000000000,
+    rawText: "",
+    processedText: null,
+    recordingDurationMs: 3000,
+    transcriptionDurationMs: 0,
+    enhancementDurationMs: null,
+    charCount: 0,
+    triggerMode: "hold",
+    wasEnhanced: false,
+    wasModified: null,
+    createdAt: "",
+    audioFilePath: "C:/rec/rec-1.wav",
+    status: "failed",
+    isEditMode: false,
+    editSourceText: null,
+    ...overrides,
+  };
+}
+
+const GOOD_TRANSCRIBE_RESULT = {
+  rawText: "這是重新辨識後得到的完整句子內容。",
+  transcriptionDurationMs: 280,
+  noSpeechProbability: 0.01,
+  peakEnergyLevel: 0.5,
+  rmsEnergyLevel: 0.1,
+};
+
+describe("useHistoryStore retry", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    h.mockDbExecute
+      .mockReset()
+      .mockResolvedValue({ rowsAffected: 1, lastInsertId: 0 });
+    h.mockInvoke.mockReset();
+    h.mockEnhanceGuard.mockReset();
+    h.mockGetTopTerms.mockReset().mockResolvedValue([]);
+    h.settingsStub.refreshApiKey.mockReset().mockResolvedValue(undefined);
+    h.settingsStub.refreshLlmApiKey.mockReset().mockResolvedValue(undefined);
+    h.settingsStub.getWhisperRequestConfig
+      .mockReset()
+      .mockResolvedValue({ apiKey: "whisper-key", provider: "groq" });
+    h.settingsStub.getLlmRequestConfig.mockReset().mockResolvedValue({
+      apiKey: "llm-key",
+      provider: "groq",
+      modelId: "llama-3.3-70b-versatile",
+    });
+  });
+
+  describe("retranscribeRecord", () => {
+    it("[P1] 成功重新辨識 → flip success、更新原文、清空整理結果", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      const store = useHistoryStore();
+      const record = createRecord();
+      store.transcriptionList.push(record);
+
+      const res = await store.retranscribeRecord(record);
+
+      expect(res.ok).toBe(true);
+      expect(h.mockInvoke).toHaveBeenCalledWith(
+        "retranscribe_from_file",
+        expect.objectContaining({ filePath: record.audioFilePath }),
+      );
+      expect(store.transcriptionList[0].status).toBe("success");
+      expect(store.transcriptionList[0].rawText).toBe(
+        GOOD_TRANSCRIBE_RESULT.rawText,
+      );
+      expect(store.transcriptionList[0].processedText).toBeNull();
+      expect(store.transcriptionList[0].wasEnhanced).toBe(false);
+    });
+
+    it("[P1] 無錄音檔 → 不呼叫後端並回 noRecordingFile", async () => {
+      const store = useHistoryStore();
+      const record = createRecord({ audioFilePath: null });
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.noRecordingFile");
+      expect(h.mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it("[P1] 空轉錄結果 → 保留 failed、不覆寫原文", async () => {
+      h.mockInvoke.mockResolvedValue({ ...GOOD_TRANSCRIBE_RESULT, rawText: "  " });
+      const store = useHistoryStore();
+      const record = createRecord({ rawText: "原本失敗" });
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.retranscribeFailed");
+      expect(store.transcriptionList[0].status).toBe("failed");
+      expect(store.transcriptionList[0].rawText).toBe("原本失敗");
+    });
+
+    it("[P2] 幻覺結果（靜音 + 高 NSP）→ 保留 failed", async () => {
+      h.mockInvoke.mockResolvedValue({
+        rawText: "幻覺出來的一長串文字但其實完全沒有人聲",
+        transcriptionDurationMs: 280,
+        noSpeechProbability: 0.95,
+        peakEnergyLevel: 0,
+        rmsEnergyLevel: 0,
+      });
+      const store = useHistoryStore();
+      const record = createRecord();
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(false);
+      expect(store.transcriptionList[0].status).toBe("failed");
+    });
+
+    it("[P2] 樂觀鎖 rowsAffected=0 → 回失敗、紀錄不變", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      h.mockDbExecute.mockResolvedValue({ rowsAffected: 0, lastInsertId: 0 });
+      const store = useHistoryStore();
+      const record = createRecord();
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(false);
+      expect(store.transcriptionList[0].status).toBe("failed");
+    });
+
+    it("[P2] recordingDurationMs<=0 仍可成功（跳過語速異常層、保留能量/NSP）", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      const store = useHistoryStore();
+      const record = createRecord({ recordingDurationMs: 0 });
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].status).toBe("success");
+    });
+
+    it("[P2] 已整理的成功紀錄重新辨識 → 清空整理、status 仍 success", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        wasEnhanced: true,
+        processedText: "舊的整理結果",
+        rawText: "舊原文",
+      });
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].status).toBe("success");
+      expect(store.transcriptionList[0].rawText).toBe(
+        GOOD_TRANSCRIBE_RESULT.rawText,
+      );
+      expect(store.transcriptionList[0].processedText).toBeNull();
+      expect(store.transcriptionList[0].wasEnhanced).toBe(false);
+    });
+  });
+
+  describe("reEnhanceRecord", () => {
+    it("[P1] 成功整理 → 寫入 processed_text、標記 was_enhanced", async () => {
+      h.mockEnhanceGuard.mockResolvedValue({
+        text: "整理後的書面語句子。",
+        usage: null,
+        wasAnomalous: false,
+      });
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        rawText: "原始口語內容",
+        wasEnhanced: false,
+      });
+      store.transcriptionList.push(record);
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].processedText).toBe(
+        "整理後的書面語句子。",
+      );
+      expect(store.transcriptionList[0].wasEnhanced).toBe(true);
+    });
+
+    it("[P1] 空原文 → 不呼叫 LLM 並回失敗", async () => {
+      const store = useHistoryStore();
+      const record = createRecord({ status: "success", rawText: "   " });
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.reEnhanceFailed");
+      expect(h.mockEnhanceGuard).not.toHaveBeenCalled();
+    });
+
+    it("[P1] 長度爆炸 anomaly → 不 finalize、保留未整理", async () => {
+      h.mockEnhanceGuard.mockResolvedValue({
+        text: "原始口語內容",
+        usage: null,
+        wasAnomalous: true,
+      });
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        rawText: "原始口語內容",
+        wasEnhanced: false,
+      });
+      store.transcriptionList.push(record);
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.reEnhanceFailed");
+      expect(store.transcriptionList[0].wasEnhanced).toBe(false);
+      expect(store.transcriptionList[0].processedText).toBeNull();
+    });
+
+    it("[P2] 已整理紀錄可再次重新整理（覆寫整理結果）", async () => {
+      h.mockEnhanceGuard.mockResolvedValue({
+        text: "新的整理結果。",
+        usage: null,
+        wasAnomalous: false,
+      });
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        wasEnhanced: true,
+        processedText: "舊整理",
+        rawText: "原始口語內容",
+      });
+      store.transcriptionList.push(record);
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].processedText).toBe("新的整理結果。");
+      expect(store.transcriptionList[0].wasEnhanced).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 變更摘要

補回「歷史記錄每筆 retry」功能（重新辨識 / 重新整理）。

### 背景
此功能原先在 `feat/history-retry-ui` 分支開發完成（含 UI 常駐摘要列、code-review 強化），但**從未合併進 main**，所以發出去的 0.11.x 沒有它——使用者反映「retry 不見了」。HUD 的錯誤 retry（↻）一直都在、不受影響。

### 做法（乾淨移植，非生硬 merge）
分支從 0.11.3 切出，但核心檔在 main 端自 base 以來 **0 次改動**，故直接取分支版本即與現行 main（0.11.7）相容：
- `src/views/HistoryView.vue`、`src/stores/useHistoryStore.ts`、`src/lib/enhancer.ts`
- 測試：`tests/unit/use-history-retry.test.ts`(11)、`tests/component/HistoryView.test.ts`(7)、`tests/unit/enhancer.test.ts`(38)

i18n 則在 main 較新的 5 語系上**併入** `history.retry*` 6 個 key（避免覆蓋 main 後加的 theme/upgradeNotice 等）。

### 相容性
`retranscribeRecord` 的 `retranscribe_from_file` 呼叫已帶 Azure-aware 參數（provider/endpoint/deployment/apiVersion/authMode），與現行 voice-flow 一致。

## 影響模組
`HistoryView.vue`、`useHistoryStore.ts`、`enhancer.ts`、`i18n/locales/*`、3 個測試檔。無 IPC 變更、無 SQL migration。

## 驗證
- vue-tsc ✅ / eslint ✅ / build 雙 entry ✅
- 56 個 retry 測試全綠（單獨/序列）

## 待人工
`pnpm tauri dev` 在歷史記錄對失敗/既有紀錄按「重新辨識 / 重新整理」確認流程（真 plugin-sql 須實機）。
