### PR TITLE
fix(theme,errors): HUD follows OS theme on Windows + informative transcription errors

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ windows = { version = "0.61", features = [
     "Win32_System_Com",
     "Win32_System_Threading",
     "Win32_UI_Accessibility",
+    "Win32_System_Registry",
 ] }
 
 [profile.dev]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,46 @@ fn update_hotkey_config(
     Ok(())
 }
 
+/// 讀取 OS 目前外觀（深/淺）。Windows 直接讀登錄檔 `AppsUseLightTheme`
+/// （0=深、1=淺），這是不受透明/隱藏視窗 WebView2 影響的權威來源；
+/// 其他平台回傳 `None`，前端沿用 `window.theme()` / matchMedia（本就正常）。
+#[cfg(target_os = "windows")]
+fn current_os_theme_is_dark() -> Option<bool> {
+    use windows::core::w;
+    use windows::Win32::Foundation::ERROR_SUCCESS;
+    use windows::Win32::System::Registry::{RegGetValueW, HKEY_CURRENT_USER, RRF_RT_REG_DWORD};
+
+    let mut data: u32 = 0;
+    let mut cb = std::mem::size_of::<u32>() as u32;
+    let status = unsafe {
+        RegGetValueW(
+            HKEY_CURRENT_USER,
+            w!(r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"),
+            w!("AppsUseLightTheme"),
+            RRF_RT_REG_DWORD,
+            None,
+            Some(&mut data as *mut u32 as *mut core::ffi::c_void),
+            Some(&mut cb),
+        )
+    };
+    if status == ERROR_SUCCESS {
+        Some(data == 0)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn current_os_theme_is_dark() -> Option<bool> {
+    None
+}
+
+/// 供前端在啟動/需要時查詢權威 OS 外觀（"dark" | "light"，未知回 null）。
+#[command]
+fn get_os_theme() -> Option<String> {
+    current_os_theme_is_dark().map(|dark| if dark { "dark" } else { "light" }.to_string())
+}
+
 /// HUD 視窗邏輯寬度（pixels），對應前端 CSS 470px
 const HUD_WINDOW_WIDTH_LOGICAL: f64 = 470.0;
 
@@ -435,6 +475,7 @@ pub fn run() {
             plugins::logging::cleanup_old_logs,
             update_hotkey_config,
             get_hud_target_position,
+            get_os_theme,
             plugins::audio_control::mute_system_audio,
             plugins::audio_control::restore_system_audio,
             plugins::clipboard_paste::capture_target_window,
@@ -495,6 +536,30 @@ pub fn run() {
             app.manage(plugins::audio_recorder::AudioPreviewState::new());
             // 初始化 transcription 狀態（共用 HTTP client）
             app.manage(plugins::transcription::TranscriptionState::new());
+
+            // Windows：輪詢 OS 外觀並廣播變更。透明+隱藏的 HUD 視窗收不到
+            // WM_THEMECHANGED（漏接/延遲），改由 Rust 讀登錄檔，變更時以
+            // `theme:os-changed` 自訂事件可靠通知所有 webview。
+            #[cfg(target_os = "windows")]
+            {
+                use tauri::Emitter;
+                let handle = app.handle().clone();
+                std::thread::spawn(move || {
+                    let mut last = current_os_theme_is_dark();
+                    loop {
+                        std::thread::sleep(std::time::Duration::from_millis(1500));
+                        let now = current_os_theme_is_dark();
+                        if now != last {
+                            last = now;
+                            if let Some(dark) = now {
+                                let payload = if dark { "dark" } else { "light" };
+                                let _ = handle.emit("theme:os-changed", payload);
+                                log::info!("[theme] OS appearance changed → broadcast {payload}");
+                            }
+                        }
+                    }
+                });
+            }
 
             let open_dashboard_item =
                 MenuItem::with_id(app, "open-dashboard", "開啟 Dashboard", true, None::<&str>)?;

--- a/src/composables/useTauriEvents.ts
+++ b/src/composables/useTauriEvents.ts
@@ -11,6 +11,11 @@ export const TRANSCRIPTION_COMPLETED = "transcription:completed" as const;
 export const SETTINGS_UPDATED = "settings:updated" as const;
 export const VOCABULARY_CHANGED = "vocabulary:changed" as const;
 
+// Rust 偵測到 OS 外觀變更時廣播（"dark" | "light"）。
+// 透明+隱藏的 HUD 視窗在 Windows 下收不到 WM_THEMECHANGED，改由 Rust
+// 以此自訂事件可靠地通知所有 webview（見 lib.rs OS 主題輪詢）。
+export const THEME_OS_CHANGED = "theme:os-changed" as const;
+
 export const HOTKEY_PRESSED = "hotkey:pressed" as const;
 export const HOTKEY_RELEASED = "hotkey:released" as const;
 export const HOTKEY_TOGGLED = "hotkey:toggled" as const;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -418,13 +418,17 @@
     "network": "Network connection lost",
     "transcription": {
       "fileTooLarge": "Recording file too large. Please shorten your recording",
+      "noAudio": "No speech detected or recording was too short",
       "invalidAudio": "Invalid audio format or incomplete recording data",
       "invalidApiKey": "API Key is invalid or expired",
       "rateLimited": "Too many requests. Please try again later",
       "serviceUnavailable": "Transcription service temporarily unavailable",
+      "parseError": "Failed to parse the transcription response",
+      "timeout": "Transcription timed out, please try again",
       "failed": "Speech transcription failed",
       "recorderError": "Recording device error",
-      "operationFailed": "Operation failed"
+      "operationFailed": "Operation failed",
+      "operationFailedWithCode": "Operation failed ({code})"
     },
     "enhancement": {
       "timeout": "AI enhancement timed out. Raw text pasted instead",
@@ -433,7 +437,8 @@
       "rateLimited": "Too many requests. Please try again later",
       "badRequest": "Model request error. Please check your settings",
       "serviceUnavailable": "AI enhancement service temporarily unavailable",
-      "failed": "AI enhancement failed"
+      "failed": "AI enhancement failed",
+      "failedWithCode": "AI cleanup failed ({code})"
     },
     "hotkey": {
       "accessibilityPermission": "Accessibility permission required",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -418,13 +418,17 @@
     "network": "ネットワーク接続が切断されました",
     "transcription": {
       "fileTooLarge": "録音ファイルが大きすぎます。録音時間を短くしてください",
+      "noAudio": "音声が検出されないか、録音データが不足しています",
       "invalidAudio": "音声ファイルの形式が無効、または録音データが不完全です",
       "invalidApiKey": "API Key が無効または期限切れです",
       "rateLimited": "リクエストが多すぎます。しばらくしてから再試行してください",
       "serviceUnavailable": "文字起こしサービスが一時的に利用できません",
+      "parseError": "文字起こし応答の解析に失敗しました",
+      "timeout": "文字起こしがタイムアウトしました。後でもう一度お試しください",
       "failed": "音声文字起こしに失敗しました",
       "recorderError": "録音デバイスでエラーが発生しました",
-      "operationFailed": "操作に失敗しました"
+      "operationFailed": "操作に失敗しました",
+      "operationFailedWithCode": "操作に失敗しました（{code}）"
     },
     "enhancement": {
       "timeout": "AI 整理がタイムアウトしました。原文を貼り付けました",
@@ -433,7 +437,8 @@
       "rateLimited": "リクエストが多すぎます。しばらくしてから再試行してください",
       "badRequest": "モデルリクエストエラーです。設定を確認してください",
       "serviceUnavailable": "AI 整理サービスが一時的に利用できません",
-      "failed": "AI 整理に失敗しました"
+      "failed": "AI 整理に失敗しました",
+      "failedWithCode": "AI整理に失敗しました（{code}）"
     },
     "hotkey": {
       "accessibilityPermission": "アクセシビリティ権限が必要です",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -418,13 +418,17 @@
     "network": "네트워크 연결이 끊어졌습니다",
     "transcription": {
       "fileTooLarge": "녹음 파일이 너무 큽니다. 녹음 시간을 줄여주세요",
+      "noAudio": "음성이 감지되지 않았거나 녹음 데이터가 부족합니다",
       "invalidAudio": "오디오 형식이 유효하지 않거나 녹음 데이터가 불완전합니다",
       "invalidApiKey": "API Key가 유효하지 않거나 만료되었습니다",
       "rateLimited": "요청이 너무 빈번합니다. 잠시 후 다시 시도하세요",
       "serviceUnavailable": "전사 서비스를 일시적으로 사용할 수 없습니다",
+      "parseError": "전사 응답을 파싱하지 못했습니다",
+      "timeout": "전사 시간이 초과되었습니다. 나중에 다시 시도하세요",
       "failed": "음성 전사 실패",
       "recorderError": "녹음 장치에 오류가 발생했습니다",
-      "operationFailed": "작업 실패"
+      "operationFailed": "작업 실패",
+      "operationFailedWithCode": "작업 실패 ({code})"
     },
     "enhancement": {
       "timeout": "AI 정리 시간 초과, 원본 텍스트를 붙여넣었습니다",
@@ -433,7 +437,8 @@
       "rateLimited": "요청이 너무 빈번합니다. 잠시 후 다시 시도하세요",
       "badRequest": "모델 요청 오류입니다. 설정을 확인해주세요",
       "serviceUnavailable": "AI 정리 서비스를 일시적으로 사용할 수 없습니다",
-      "failed": "AI 정리 실패"
+      "failed": "AI 정리 실패",
+      "failedWithCode": "AI 정리 실패 ({code})"
     },
     "hotkey": {
       "accessibilityPermission": "손쉬운 사용 권한이 필요합니다",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -418,13 +418,17 @@
     "network": "网络连接中断",
     "transcription": {
       "fileTooLarge": "录音文件过大，请缩短录音时间",
+      "noAudio": "未检测到语音或录音数据不足",
       "invalidAudio": "音频格式无效或录音数据不完整",
       "invalidApiKey": "API Key 无效或已过期",
       "rateLimited": "请求过于频繁，稍后再试",
       "serviceUnavailable": "转录服务暂时无法使用",
+      "parseError": "转录响应解析失败",
+      "timeout": "转录超时，请稍后再试",
       "failed": "语音转录失败",
       "recorderError": "录音设备发生错误",
-      "operationFailed": "操作失败"
+      "operationFailed": "操作失败",
+      "operationFailedWithCode": "操作失败（{code}）"
     },
     "enhancement": {
       "timeout": "AI 整理超时，已粘贴原始文字",
@@ -433,7 +437,8 @@
       "rateLimited": "请求过于频繁，稍后再试",
       "badRequest": "模型请求错误，请检查设置",
       "serviceUnavailable": "AI 整理服务暂时无法使用",
-      "failed": "AI 整理失败"
+      "failed": "AI 整理失败",
+      "failedWithCode": "AI 整理失败（{code}）"
     },
     "hotkey": {
       "accessibilityPermission": "需要辅助使用权限",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -418,13 +418,17 @@
     "network": "網路連線中斷",
     "transcription": {
       "fileTooLarge": "錄音檔案過大，請縮短錄音時間",
+      "noAudio": "未偵測到語音或錄音資料不足",
       "invalidAudio": "音檔格式無效或錄音資料不完整",
       "invalidApiKey": "API Key 無效或已過期",
       "rateLimited": "請求過於頻繁，稍後再試",
       "serviceUnavailable": "轉錄服務暫時無法使用",
+      "parseError": "轉錄回應解析失敗",
+      "timeout": "轉錄逾時，請稍後再試",
       "failed": "語音轉錄失敗",
       "recorderError": "錄音裝置發生錯誤",
-      "operationFailed": "操作失敗"
+      "operationFailed": "操作失敗",
+      "operationFailedWithCode": "操作失敗（{code}）"
     },
     "enhancement": {
       "timeout": "AI 整理逾時，已貼原始文字",
@@ -433,7 +437,8 @@
       "rateLimited": "請求過於頻繁，稍後再試",
       "badRequest": "模型請求錯誤，請檢查設定",
       "serviceUnavailable": "AI 整理服務暫時無法使用",
-      "failed": "AI 整理失敗"
+      "failed": "AI 整理失敗",
+      "failedWithCode": "AI 整理失敗（{code}）"
     },
     "hotkey": {
       "accessibilityPermission": "需要輔助使用權限",

--- a/src/lib/errorUtils.ts
+++ b/src/lib/errorUtils.ts
@@ -9,6 +9,12 @@ export function extractErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+export function buildDiagnosticCode(message: string): string {
+  const cleaned = message.replace(/\s+/g, " ").trim();
+  if (cleaned.length === 0) return "unknown";
+  return cleaned.length > 80 ? `${cleaned.slice(0, 80)}…` : cleaned;
+}
+
 export function getMicrophoneErrorMessage(error: unknown): string {
   // Rust AudioRecorderError 字串匹配（透過 Tauri invoke 傳來的字串錯誤）
   const message = extractErrorMessage(error);
@@ -58,6 +64,21 @@ export function getTranscriptionErrorMessage(error: unknown): string {
     return t("errors.network");
   }
 
+  if (
+    message.includes("No audio data") ||
+    message.includes("Audio data too small")
+  ) {
+    return t("errors.transcription.noAudio");
+  }
+
+  if (message.includes("API key is missing")) {
+    return t("errors.apiKeyMissing");
+  }
+
+  if (message.includes("Failed to parse API response")) {
+    return t("errors.transcription.parseError");
+  }
+
   if (message.includes("Audio file too large")) {
     return t("errors.transcription.fileTooLarge");
   }
@@ -68,8 +89,17 @@ export function getTranscriptionErrorMessage(error: unknown): string {
       const status = parseInt(statusMatch[1], 10);
       if (status === 400) return t("errors.transcription.invalidAudio");
       if (status === 401) return t("errors.transcription.invalidApiKey");
+      if (status === 403) return t("errors.transcription.invalidApiKey");
+      if (status === 408 || status === 504) {
+        return t("errors.transcription.timeout");
+      }
+      if (status === 413) return t("errors.transcription.fileTooLarge");
+      if (status === 422) return t("errors.transcription.invalidAudio");
       if (status === 429) return t("errors.transcription.rateLimited");
       if (status >= 500) return t("errors.transcription.serviceUnavailable");
+      return t("errors.transcription.operationFailedWithCode", {
+        code: `HTTP ${status}`,
+      });
     }
     return t("errors.transcription.failed");
   }
@@ -78,7 +108,9 @@ export function getTranscriptionErrorMessage(error: unknown): string {
     return t("errors.transcription.recorderError");
   }
 
-  return t("errors.transcription.operationFailed");
+  return t("errors.transcription.operationFailedWithCode", {
+    code: buildDiagnosticCode(message),
+  });
 }
 
 export function getEnhancementErrorMessage(error: unknown): string {
@@ -107,7 +139,9 @@ export function getEnhancementErrorMessage(error: unknown): string {
     }
   }
 
-  return t("errors.enhancement.failed");
+  return t("errors.enhancement.failedWithCode", {
+    code: buildDiagnosticCode(extractErrorMessage(error)),
+  });
 }
 
 const HOTKEY_ERROR_KEY_MAP: Record<string, string> = {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,7 +1,9 @@
 /// <reference types="vite/client" />
 import { load } from "@tauri-apps/plugin-store";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { invoke } from "@tauri-apps/api/core";
 import { THEME_MODE_VALUES, type ThemeMode } from "../types/settings";
+import { listenToEvent, THEME_OS_CHANGED } from "../composables/useTauriEvents";
 
 const STORE_NAME = "settings.json";
 const THEME_STORE_KEY = "themeMode";
@@ -13,12 +15,14 @@ let mediaQuery: MediaQueryList | null = null;
 let systemListener: ((event: MediaQueryListEvent) => void) | null = null;
 let activeMode: ThemeMode = DEFAULT_THEME_MODE;
 
-// OS 外觀以 Tauri 視窗主題 API 為權威來源（跨平台一致）；
-// 透明的 HUD WebView 在 Windows 下 CSS matchMedia 不一定反映 OS 外觀，
-// 故快取 Tauri 回報的 OS 主題，matchMedia 僅作為非 Tauri / null 時的 fallback。
+// OS 外觀權威來源優先序：Rust `get_os_theme`（Windows 讀登錄檔，不受透明/隱藏
+// 視窗 WebView2 影響）→ Tauri `window.theme()` → matchMedia（最後 fallback）。
+// 透明+隱藏的 HUD 在 Windows 收不到 WM_THEMECHANGED，故 OS 變更改由 Rust 以
+// `theme:os-changed` 自訂事件可靠廣播（見下方 ensureOsThemeBroadcastListener）。
 let osThemeDark: boolean | null = null;
 let osWatcherInit = false;
 let unlistenOsThemeWatcher: (() => void) | null = null;
+let unlistenOsThemeBroadcast: (() => void) | null = null;
 
 export function isThemeMode(value: unknown): value is ThemeMode {
   return (
@@ -40,8 +44,23 @@ export function resolveTheme(mode: ThemeMode): "light" | "dark" {
   return mode === "system" ? (prefersDark() ? "dark" : "light") : mode;
 }
 
-// 以 Tauri 視窗主題 API 取得權威 OS 外觀，快取供同步的 applyTheme 使用
+// 取得權威 OS 外觀，快取供同步的 applyTheme 使用。
+// 優先 Rust `get_os_theme`（Windows 讀登錄檔，最可靠）→ Tauri `window.theme()`。
 async function refreshOsTheme(): Promise<void> {
+  try {
+    const osTheme = await invoke<string | null>("get_os_theme");
+    if (osTheme === "dark") {
+      osThemeDark = true;
+      return;
+    }
+    if (osTheme === "light") {
+      osThemeDark = false;
+      return;
+    }
+    // null（非 Windows / 讀取失敗）→ 往下 fallback
+  } catch {
+    // 非 Tauri 環境或 command 未註冊：往下 fallback
+  }
   try {
     const t = await getCurrentWindow().theme();
     if (t === "dark") osThemeDark = true;
@@ -70,12 +89,33 @@ async function ensureOsThemeWatcher(): Promise<void> {
   }
 }
 
+// 訂閱 Rust 廣播的 OS 外觀變更（`theme:os-changed`）。透明+隱藏的 HUD 在
+// Windows 收不到 WM_THEMECHANGED，此自訂事件走可靠 IPC，所有視窗皆能即時跟隨。
+async function ensureOsThemeBroadcastListener(): Promise<void> {
+  if (unlistenOsThemeBroadcast) return;
+  try {
+    unlistenOsThemeBroadcast = await listenToEvent<string>(
+      THEME_OS_CHANGED,
+      ({ payload }) => {
+        osThemeDark = payload === "dark";
+        if (activeMode === "system") {
+          document.documentElement.classList.toggle("dark", osThemeDark);
+        }
+      },
+    );
+  } catch {
+    // 監聽失敗允許之後重試（下次 initThemeFromStore）
+  }
+}
+
 // Vite HMR：模組熱替換時解除舊訂閱，避免 dev 期間重複監聽
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
     unlistenOsThemeWatcher?.();
     unlistenOsThemeWatcher = null;
     osWatcherInit = false;
+    unlistenOsThemeBroadcast?.();
+    unlistenOsThemeBroadcast = null;
   });
 }
 
@@ -118,6 +158,7 @@ export async function initThemeFromStore(): Promise<ThemeMode> {
   // 先取得權威 OS 主題並訂閱變更，確保 system 模式在所有視窗解析一致
   await refreshOsTheme();
   void ensureOsThemeWatcher();
+  void ensureOsThemeBroadcastListener();
 
   let mode = DEFAULT_THEME_MODE;
   try {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -155,10 +155,12 @@ export function applyTheme(mode: ThemeMode): void {
 
 // mount 前盡早讀取持久化主題並套用，避免閃白
 export async function initThemeFromStore(): Promise<ThemeMode> {
-  // 先取得權威 OS 主題並訂閱變更，確保 system 模式在所有視窗解析一致
-  await refreshOsTheme();
+  // 先註冊 OS 外觀廣播監聽，再做權威讀取：避免「監聽就緒前 OS 剛好變更、
+  // Rust poll 已 emit 而前端漏接」的啟動競態（poll 不 replay current state，
+  // 故 listener 須先就緒；之後 refreshOsTheme 直接讀登錄檔取得當下真值補正）。
   void ensureOsThemeWatcher();
-  void ensureOsThemeBroadcastListener();
+  await ensureOsThemeBroadcastListener();
+  await refreshOsTheme();
 
   let mode = DEFAULT_THEME_MODE;
   try {

--- a/tests/unit/error-utils.test.ts
+++ b/tests/unit/error-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildDiagnosticCode,
   getEnhancementErrorMessage,
   getHotkeyErrorMessage,
   getMicrophoneErrorMessage,
@@ -58,7 +59,7 @@ describe("getTranscriptionErrorMessage", () => {
 
   it("[P0] 轉錄 API 未知狀態碼應映射為語音轉錄失敗", () => {
     const error = new Error("Transcription API error (418): I'm a teapot");
-    expect(getTranscriptionErrorMessage(error)).toBe("語音轉錄失敗");
+    expect(getTranscriptionErrorMessage(error)).toContain("HTTP 418");
   });
 
   it("[P0] 轉錄 API 無狀態碼應映射為語音轉錄失敗", () => {
@@ -104,7 +105,9 @@ describe("getTranscriptionErrorMessage", () => {
   });
 
   it("[P0] 未知錯誤應回傳操作失敗", () => {
-    expect(getTranscriptionErrorMessage("some string error")).toBe("操作失敗");
+    expect(getTranscriptionErrorMessage("some string error")).toBe(
+      "操作失敗（some string error）",
+    );
   });
 
   it("[P0] Tauri HTTP network error 應映射為網路連線中斷", () => {
@@ -144,6 +147,63 @@ describe("getTranscriptionErrorMessage", () => {
         new Error("Transcription API error (500): network issue on server"),
       ),
     ).toBe("轉錄服務暫時無法使用");
+  });
+
+  it("[P2] 無錄音資料應映射為未偵測到語音", () => {
+    expect(
+      getTranscriptionErrorMessage(
+        "No audio data available — call stop_recording first",
+      ),
+    ).toBe("未偵測到語音或錄音資料不足");
+  });
+
+  it("[P2] 錄音資料太小應映射為未偵測到語音", () => {
+    expect(
+      getTranscriptionErrorMessage(
+        "Audio data too small (123 bytes), recording may have failed",
+      ),
+    ).toBe("未偵測到語音或錄音資料不足");
+  });
+
+  it("[P2] 轉錄回應解析失敗應映射為解析失敗", () => {
+    expect(
+      getTranscriptionErrorMessage("Failed to parse API response: xyz"),
+    ).toBe("轉錄回應解析失敗");
+  });
+
+  it("[P2] 轉錄 API 403 應映射為 API Key 無效", () => {
+    expect(
+      getTranscriptionErrorMessage("Transcription API error (403): Forbidden"),
+    ).toBe("API Key 無效或已過期");
+  });
+
+  it("[P2] 轉錄 API 504 應映射為逾時", () => {
+    expect(
+      getTranscriptionErrorMessage("Transcription API error (504): Timeout"),
+    ).toBe("轉錄逾時，請稍後再試");
+  });
+
+  it("[P2] 轉錄 API 未映射狀態碼應包含 HTTP 診斷碼", () => {
+    expect(
+      getTranscriptionErrorMessage("Transcription API error (418): teapot"),
+    ).toContain("HTTP 418");
+  });
+
+  it("[P2] 未知轉錄錯誤應包含原始診斷碼", () => {
+    expect(getTranscriptionErrorMessage("Lock poisoned")).toBe(
+      "操作失敗（Lock poisoned）",
+    );
+  });
+});
+
+describe("buildDiagnosticCode", () => {
+  it("[P2] 空白訊息應回傳 unknown", () => {
+    expect(buildDiagnosticCode("   \n\t  ")).toBe("unknown");
+  });
+
+  it("[P2] 長訊息應截斷為 80 字元並加上省略號", () => {
+    const message = "a".repeat(81);
+    expect(buildDiagnosticCode(message)).toBe(`${"a".repeat(80)}…`);
   });
 });
 


### PR DESCRIPTION
## 變更摘要 / Change Summary

兩個相對獨立的修正：

### 1. 深色 HUD 修正（system 模式 / Windows）
**問題**：主題設「跟隨系統」、系統為深色時，HUD（靈動島浮窗）仍顯示淺色；Dashboard 正常。
**根因（實機確認）**：透明+隱藏的 HUD 視窗在 Windows/WebView2 下收 `WM_THEMECHANGED` 不可靠（漏接/延遲），OS 主題變更後 HUD 卡在過期主題。啟動解析本身正常。
**修法**：
- Rust 新增 `get_os_theme` command（讀登錄檔 `AppsUseLightTheme`，權威且不受透明/隱藏視窗影響）。
- Rust 背景輪詢（1.5s）偵測 OS 外觀變更，`emit("theme:os-changed")` 廣播給所有 webview；自訂事件走可靠 IPC，隱藏的 HUD 也收得到。
- `theme.ts`：`refreshOsTheme()` 優先用 `get_os_theme`；新增 `theme:os-changed` 監聽（system 模式套用）；保留既有 `onThemeChanged`/matchMedia 當 fallback。
- 影響檔案：`src-tauri/src/lib.rs`、`src-tauri/Cargo.toml`（+`Win32_System_Registry` feature）、`src/lib/theme.ts`、`src/composables/useTauriEvents.ts`。

### 2. 轉錄錯誤訊息加強（upstream chenjackle45/SayIt#38）
**問題**：未對應的轉錄/整理錯誤一律 fall through 成無資訊的「操作失敗」，技術細節只進 log/Sentry。
**修法**：
- `errorUtils.ts` 擴充對應：no-audio、parse error、HTTP 403/408/413/422/504。
- 未知 fallback 改為附帶簡短診斷碼（`operationFailedWithCode` / `failedWithCode`），五語系同步新增。
- 影響檔案：`src/lib/errorUtils.ts`、`src/i18n/locales/*.json`、`tests/unit/error-utils.test.ts`。

### IPC 變更
- 新 command：`get_os_theme`（已註冊於 `generate_handler!`）。
- 新 Rust→Frontend 事件：`theme:os-changed`（payload `"dark"|"light"`）。
