### PR TITLE
feat(sentry): scrub PII from telemetry events

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -422,6 +422,16 @@ pub fn run() {
                 release: Some(get_sentry_release().into()),
                 environment: Some(get_sentry_environment().into()),
                 send_default_pii: false,
+                before_send: Some(std::sync::Arc::new(
+                    |mut event: sentry::protocol::Event<'static>| {
+                        // 隱私硬規則：不外洩主機名稱與 request（URL/headers/cookies）。
+                        // Rust 端僅透過 panic integration 上報，事件不含轉錄文字/字典詞/金鑰，
+                        // 故此處只需防禦性清除識別性欄位。
+                        event.server_name = None;
+                        event.request = None;
+                        Some(event)
+                    },
+                )),
                 ..Default::default()
             },
         )))

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -2,6 +2,11 @@
 import * as Sentry from "@sentry/vue";
 import type { App } from "vue";
 import type { Router } from "vue-router";
+import {
+  isValidSentryDsn,
+  scrubBreadcrumb,
+  scrubEvent,
+} from "./sentryScrubbing";
 
 declare const __APP_VERSION__: string;
 
@@ -26,7 +31,7 @@ function getTracesSampleRate(): number {
 }
 
 function isSentryEnabled(): boolean {
-  return import.meta.env.PROD && Boolean(getSentryDsn());
+  return import.meta.env.PROD && isValidSentryDsn(getSentryDsn());
 }
 
 export function initSentryForHud(app: App): void {
@@ -38,6 +43,8 @@ export function initSentryForHud(app: App): void {
     environment: getSentryEnvironment(),
     release: getSentryRelease(),
     sendDefaultPii: false,
+    beforeSend: (event) => scrubEvent(event),
+    beforeBreadcrumb: (breadcrumb) => scrubBreadcrumb(breadcrumb),
     integrations: [],
     initialScope: {
       tags: { window: "hud" },
@@ -56,6 +63,8 @@ export function initSentryForDashboard(app: App, router: Router): void {
     environment: getSentryEnvironment(),
     release: getSentryRelease(),
     sendDefaultPii: false,
+    beforeSend: (event) => scrubEvent(event),
+    beforeBreadcrumb: (breadcrumb) => scrubBreadcrumb(breadcrumb),
     integrations:
       tracesSampleRate > 0 ? [Sentry.browserTracingIntegration({ router })] : [],
     ...(tracesSampleRate > 0 ? { tracesSampleRate } : {}),

--- a/src/lib/sentryScrubbing.ts
+++ b/src/lib/sentryScrubbing.ts
@@ -1,0 +1,105 @@
+import type { Breadcrumb, Event } from "@sentry/vue";
+
+// 隱私硬規則：以下敏感資料絕不可進入任何 Sentry event / breadcrumb
+// （轉錄/LLM 文字、字典詞、API key·Azure 憑證·Entra token、其他 App 文字、剪貼簿）。
+// 採 default-deny：extra 只保留已知安全鍵，其餘一律移除；可樣式化的祕密再額外遮罩。
+
+const SAFE_EXTRA_KEYS = new Set(["source", "step", "window", "info"]);
+
+const REDACTION = "[redacted]";
+
+// 可用樣式偵測的祕密（API key / token / 含使用者名的路徑）。任意自然語言（轉錄文字等）
+// 無法以樣式可靠偵測，因此主要靠 default-deny 結構與「不把敏感內容放進上報欄位」的程式紀律。
+const SENSITIVE_PATTERNS: readonly RegExp[] = [
+  /\b(?:sk-ant|sk-proj|sk|gsk|sntrys|sntryu)[-_][A-Za-z0-9._-]{10,}/gi,
+  /\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}/g,
+  /\bBearer\s+[A-Za-z0-9._~+/-]{10,}=*/gi,
+  /\bapi-key["']?\s*[:=]\s*["']?[A-Za-z0-9._-]{8,}/gi,
+  /[A-Za-z]:\\Users\\[^\\/\r\n"']+/gi,
+  /\/Users\/[^/\r\n"']+/g,
+];
+
+export function redactSensitiveString(value: string): string {
+  return SENSITIVE_PATTERNS.reduce((acc, re) => acc.replace(re, REDACTION), value);
+}
+
+// 鏡像 Rust 端（lib.rs）的 DSN 過濾：忽略空字串與 CI 佔位符（`__` 開頭）。
+export function isValidSentryDsn(dsn: string | undefined | null): boolean {
+  const trimmed = dsn?.trim() ?? "";
+  return trimmed.length > 0 && !trimmed.startsWith("__");
+}
+
+// console 與輸入框（ui.input）breadcrumb 可能夾帶轉錄文字 / 剪貼簿內容 → 整顆丟棄。
+const DROPPED_BREADCRUMB_CATEGORIES = new Set(["console", "ui.input"]);
+
+function stripUrlQuery(url: string): string {
+  const cutIndex = url.search(/[?#]/);
+  return cutIndex >= 0 ? url.slice(0, cutIndex) : url;
+}
+
+export function scrubBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb | null {
+  if (DROPPED_BREADCRUMB_CATEGORIES.has(breadcrumb.category ?? "")) {
+    return null;
+  }
+
+  const scrubbed: Breadcrumb = { ...breadcrumb };
+
+  if (typeof scrubbed.message === "string") {
+    scrubbed.message = redactSensitiveString(scrubbed.message);
+  }
+
+  if (scrubbed.data && typeof scrubbed.data === "object") {
+    const data: Record<string, unknown> = { ...scrubbed.data };
+    if (typeof data.url === "string") {
+      data.url = redactSensitiveString(stripUrlQuery(data.url));
+    }
+    scrubbed.data = data;
+  }
+
+  return scrubbed;
+}
+
+export function scrubEvent<T extends Event>(event: T): T {
+  if (typeof event.message === "string") {
+    event.message = redactSensitiveString(event.message);
+  }
+
+  if (event.exception?.values) {
+    for (const exception of event.exception.values) {
+      if (typeof exception.value === "string") {
+        exception.value = redactSensitiveString(exception.value);
+      }
+    }
+  }
+
+  // default-deny：只保留白名單 extra 鍵，其餘移除，避免轉錄文字等敏感資料外洩。
+  if (event.extra) {
+    const safeExtra: Record<string, unknown> = {};
+    for (const key of Object.keys(event.extra)) {
+      if (!SAFE_EXTRA_KEYS.has(key)) continue;
+      const value = event.extra[key];
+      safeExtra[key] =
+        typeof value === "string" ? redactSensitiveString(value) : value;
+    }
+    event.extra = safeExtra;
+  }
+
+  // Vue 元件 props 可能含轉錄文字 → 移除。
+  const vueContext = event.contexts?.vue as Record<string, unknown> | undefined;
+  if (vueContext && "propsData" in vueContext) {
+    delete vueContext.propsData;
+  }
+
+  // request（URL/query/headers/cookies）可能含 token、user / server_name 屬識別資訊 → 移除。
+  if (event.request) delete event.request;
+  if (event.user) delete event.user;
+  if (event.server_name) delete event.server_name;
+
+  if (event.breadcrumbs) {
+    event.breadcrumbs = event.breadcrumbs
+      .map((crumb) => scrubBreadcrumb(crumb))
+      .filter((crumb): crumb is Breadcrumb => crumb !== null);
+  }
+
+  return event;
+}

--- a/src/stores/useVoiceFlowStore.ts
+++ b/src/stores/useVoiceFlowStore.ts
@@ -425,7 +425,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
     playSoundIfEnabled("play_error_sound");
     writeErrorLog(logMessage);
     if (error) {
-      captureError(error, { userMessage: errorMessage, source: "voice-flow" });
+      captureError(error, { source: "voice-flow", step: "recording" });
     }
   }
 

--- a/tests/unit/sentry-scrubbing.test.ts
+++ b/tests/unit/sentry-scrubbing.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import type { Breadcrumb, Event } from "@sentry/vue";
+import {
+  isValidSentryDsn,
+  redactSensitiveString,
+  scrubBreadcrumb,
+  scrubEvent,
+} from "../../src/lib/sentryScrubbing";
+
+describe("redactSensitiveString", () => {
+  it("[P0] 遮罩 OpenAI / Groq / Anthropic 風格的 API key", () => {
+    expect(redactSensitiveString("key sk-proj-ABCDEF0123456789xyz done")).toBe(
+      "key [redacted] done",
+    );
+    expect(redactSensitiveString("gsk_ABCDEFGHIJ0123456789")).toBe("[redacted]");
+    expect(redactSensitiveString("sk-ant-ABCDEFGHIJ0123456789")).toBe(
+      "[redacted]",
+    );
+  });
+
+  it("[P0] 遮罩 Entra JWT 與 Bearer token", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    expect(redactSensitiveString(`token ${jwt}`)).toBe("token [redacted]");
+    expect(
+      redactSensitiveString("Authorization: Bearer abcdef0123456789ABCDEF"),
+    ).toContain("[redacted]");
+  });
+
+  it("[P1] 遮罩含 Windows 使用者名的路徑", () => {
+    expect(
+      redactSensitiveString("failed at C:\\Users\\alice\\AppData\\app.db"),
+    ).toBe("failed at [redacted]\\AppData\\app.db");
+  });
+
+  it("[P1] 一般文字不受影響", () => {
+    expect(redactSensitiveString("transcription failed (429)")).toBe(
+      "transcription failed (429)",
+    );
+  });
+});
+
+describe("isValidSentryDsn", () => {
+  it("[P0] 空字串 / undefined / null 視為無效", () => {
+    expect(isValidSentryDsn("")).toBe(false);
+    expect(isValidSentryDsn("   ")).toBe(false);
+    expect(isValidSentryDsn(undefined)).toBe(false);
+    expect(isValidSentryDsn(null)).toBe(false);
+  });
+
+  it("[P0] `__` 開頭的 CI 佔位符視為無效", () => {
+    expect(isValidSentryDsn("__VITE_SENTRY_DSN__")).toBe(false);
+  });
+
+  it("[P0] 真實 DSN 視為有效", () => {
+    expect(
+      isValidSentryDsn("https://abc@o123.ingest.us.sentry.io/456"),
+    ).toBe(true);
+  });
+});
+
+describe("scrubBreadcrumb", () => {
+  it("[P0] console breadcrumb 整顆丟棄（可能含轉錄文字）", () => {
+    expect(scrubBreadcrumb({ category: "console", message: "我說的祕密" })).toBeNull();
+  });
+
+  it("[P0] ui.input breadcrumb 整顆丟棄（可能含輸入內容）", () => {
+    expect(scrubBreadcrumb({ category: "ui.input" })).toBeNull();
+  });
+
+  it("[P1] fetch breadcrumb 去除 URL query 並遮罩祕密", () => {
+    const result = scrubBreadcrumb({
+      category: "fetch",
+      data: { url: "https://api.example.com/v1?api-key=secret012345678" },
+    });
+    expect(result).not.toBeNull();
+    expect((result?.data as Record<string, unknown>).url).toBe(
+      "https://api.example.com/v1",
+    );
+  });
+
+  it("[P1] 一般 breadcrumb 的 message 經過遮罩", () => {
+    const result = scrubBreadcrumb({
+      category: "navigation",
+      message: "Bearer abcdef0123456789ABCDEF",
+    });
+    expect(result?.message).toContain("[redacted]");
+  });
+});
+
+describe("scrubEvent", () => {
+  it("[P0] extra 只保留白名單鍵，移除轉錄文字 / 字典詞等敏感鍵", () => {
+    const event: Event = {
+      extra: {
+        source: "voice-flow",
+        step: "enhancement",
+        transcript: "使用者說的全文",
+        vocabularyTerm: "某專案名",
+        userMessage: "轉錄失敗",
+      },
+    };
+    const result = scrubEvent(event);
+    expect(result.extra).toEqual({ source: "voice-flow", step: "enhancement" });
+    expect(result.extra).not.toHaveProperty("transcript");
+    expect(result.extra).not.toHaveProperty("vocabularyTerm");
+    expect(result.extra).not.toHaveProperty("userMessage");
+  });
+
+  it("[P0] 遮罩 message 與 exception value 內的祕密", () => {
+    const event: Event = {
+      message: "failed with sk-proj-ABCDEF0123456789",
+      exception: {
+        values: [{ type: "Error", value: "Bearer abcdef0123456789ABCDEF" }],
+      },
+    };
+    const result = scrubEvent(event);
+    expect(result.message).toBe("failed with [redacted]");
+    expect(result.exception?.values?.[0].value).toContain("[redacted]");
+  });
+
+  it("[P0] 移除 request / user / server_name", () => {
+    const event = {
+      request: { url: "https://x/y?token=abc", headers: { a: "b" } },
+      user: { id: "1", ip_address: "1.2.3.4" },
+      server_name: "ALICE-PC",
+    } as unknown as Event;
+    const result = scrubEvent(event);
+    expect(result.request).toBeUndefined();
+    expect(result.user).toBeUndefined();
+    expect(result.server_name).toBeUndefined();
+  });
+
+  it("[P0] 移除 Vue 元件 propsData（可能含轉錄文字）", () => {
+    const event: Event = {
+      contexts: {
+        vue: { componentName: "NotchHud", propsData: { text: "祕密全文" } },
+      },
+    };
+    const result = scrubEvent(event);
+    const vue = result.contexts?.vue as Record<string, unknown>;
+    expect(vue).not.toHaveProperty("propsData");
+    expect(vue.componentName).toBe("NotchHud");
+  });
+
+  it("[P0] event.breadcrumbs 內的 console breadcrumb 被移除", () => {
+    const event: Event = {
+      breadcrumbs: [
+        { category: "console", message: "祕密" },
+        { category: "navigation", message: "/settings" },
+      ],
+    };
+    const result = scrubEvent(event);
+    expect(result.breadcrumbs).toHaveLength(1);
+    expect(result.breadcrumbs?.[0].category).toBe("navigation");
+  });
+});


### PR DESCRIPTION
## 變更摘要 / Change Summary

Sentry 強化計畫 Phase 1：落實隱私硬規則——以下 5 類資料**絕不**進入任何 Sentry event/breadcrumb：轉錄/LLM 文字、字典詞、API key·Azure 憑證·Entra token、其他 App 的游標欄位文字、剪貼簿內容。

### Implementation
- **`src/lib/sentryScrubbing.ts`**（新增）：純函式、可單元測試的 scrubber
  - `scrubEvent`（beforeSend）：default-deny `extra`（白名單 `source/step/window/info`）、移除 `request`/`user`/`server_name`、移除 Vue `propsData`、scrub 內嵌 breadcrumbs、對 message 與 exception value 做 key/token/path 樣式遮罩。
  - `scrubBreadcrumb`（beforeBreadcrumb）：丟棄 `console`/`ui.input` breadcrumb、移除 URL query、遮罩 message。
  - `isValidSentryDsn`：鏡像 Rust 的 `__` 佔位過濾，前端 DSN 也套用。
- 將 `beforeSend`/`beforeBreadcrumb` 接進 HUD 與 Dashboard 兩個 `Sentry.init`。
- 移除 voice-flow 錄音失敗 `captureError` 的 `userMessage` 欄位。
- **Rust**（`lib.rs`）：`before_send` 防禦性清除 `server_name`/`request`（Rust 僅 panic 上報、本就無敏感內容；`send_default_pii` 維持 false）。

### Notes
- 維持 `sendDefaultPii: false`、不啟用 Session Replay。
- 自由格式錯誤訊息靠程式紀律（不把轉錄文字丟進 throw）；樣式遮罩為 key/path 的 defense-in-depth。
- 本 PR **尚未啟用**前端 telemetry——需 CSP 修正（Phase 1b），刻意排在 scrubbers 之後。