### PR TITLE
feat(sentry): allow Sentry ingest host in CSP connect-src

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,7 +48,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://api.groq.com https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://*.openai.azure.com https://*.services.ai.azure.com https://*.cognitiveservices.azure.com https://login.microsoftonline.com; style-src 'self' 'unsafe-inline'; script-src 'self'; media-src 'self' blob: http://asset.localhost",
+      "csp": "default-src 'self'; connect-src 'self' https://api.groq.com https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://*.openai.azure.com https://*.services.ai.azure.com https://*.cognitiveservices.azure.com https://login.microsoftonline.com https://o4508884668383232.ingest.us.sentry.io; style-src 'self' 'unsafe-inline'; script-src 'self'; media-src 'self' blob: http://asset.localhost",
       "assetProtocol": {
         "enable": true,
         "scope": [


### PR DESCRIPTION
## 變更摘要 / Change Summary

Sentry 強化計畫 Phase 1b：把 Sentry ingest host 加進 `tauri.conf.json` 的 CSP `connect-src`,讓前端 @sentry/vue 事件能離開 WebView。

**為何需要**：前端 SDK 用 WebView 原生 fetch 送事件(不經 plugin-http,故 `capabilities/default.json` 無關),只受 CSP `connect-src` 約束。Phase 0 盤點證實過去 90 天 **0 事件**、`window:hud/dashboard` tag 從未出現 → 前端事件一直被 CSP 封鎖。

### Change
- `connect-src` 新增 `https://o4508884668383232.ingest.us.sentry.io`(US region,取自專案 DSN)。
- **相依 #10(已合併)**:在 `beforeSend`/`beforeBreadcrumb` scrubbers 就位後才放行 CSP。

### ⚠️ 合併前請注意
- 這是「**開啟前端雲端 telemetry**」的步驟;我刻意**未自動合併**,留給你確認。
- **執行期驗證待補**:本機 build 不送事件(未注入 DSN)。建議在帶 `VITE_SENTRY_DSN` 的 build 或下次發版時,實跑 app 觸發一個錯誤,確認 Sentry 收到(且已遮罩)。