### PR TITLE
ci(sentry): associate commits and track deploys on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
 
       - name: Resolve release metadata
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           prerelease: false
           args: ${{ matrix.args }}
 
-      - name: Upload frontend sourcemaps to Sentry
+      - name: Sentry release — sourcemaps, commits, deploy
         if: matrix.upload_sourcemaps == 'true'
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -130,12 +130,18 @@ jobs:
           fi
 
           npx @sentry/cli releases new "$SENTRY_RELEASE" || true
+          # Phase 5: associate commits to enable suspect-commits. Requires the repo
+          # added in Sentry (Settings > Integrations > GitHub); non-fatal so the
+          # release still succeeds if not yet configured.
+          npx @sentry/cli releases set-commits "$SENTRY_RELEASE" --auto || true
           npx @sentry/cli sourcemaps upload dist/assets \
             --release "$SENTRY_RELEASE" \
             --url-prefix "~/assets" \
             --validate \
             --wait
           npx @sentry/cli releases finalize "$SENTRY_RELEASE" || true
+          # Phase 8: mark a production deploy for this release (non-fatal).
+          npx @sentry/cli releases deploys "$SENTRY_RELEASE" new -e production || true
 
       - name: Upload stable-name asset (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
## 變更摘要 / Change Summary

Sentry 強化計畫 Phase 5 + 8：在既有的 Sentry release 步驟(mac arm64,release 在此建立)加入兩個**非致命**步驟。

- **Phase 5** `releases set-commits --auto`：關聯 commit,啟用 suspect-commits。需先在 Sentry 加入 `lettucebo/SayIt` repo(Settings > Integrations > GitHub > Add repo);未設定前 `|| true` 不影響發版。
- **Phase 8** `releases deploys ... new -e production`：每次 release 記錄 production deploy。

皆只在 Sentry secrets 存在且 `upload_sourcemaps == 'true'` 時執行,沿用既有 sourcemap 上傳模式;**不改 build/runtime**。

### 合併前注意
- 屬 release CI 變更,刻意**未自動合併**;建議你下次發版時觀察這兩步。
- set-commits 要生效需先在 Sentry 加入 repo(盤點發現尚未加入,只有 MTTHelper2/origin)。

Verified: YAML 解析通過;diff 全在既有 `run:` 區塊內。