### PR TITLE
fix(theme): HUD notch now honors dark mode

### DIFF
--- a/src/components/NotchHud.vue
+++ b/src/components/NotchHud.vue
@@ -503,7 +503,7 @@ onUnmounted(() => {
     background 0.3s ease;
 }
 
-:global(html.dark) .notch-hud {
+html.dark .notch-hud {
   --notch-bg: #000000;
   --notch-fg: #ffffff;
   --notch-fg-soft: rgba(255, 255, 255, 0.4);


### PR DESCRIPTION
## 變更摘要 / Change Summary

修正 HUD notch 無論選「深色 / 淺色 / 跟隨系統」都顯示淺色的問題。

### 問題
HUD（NotchHud）永遠淺色，即使 `<html>` 已正確帶上 `.dark`（深色、以及跟隨系統且 OS 為深色時都會加上）。

### 根本原因
`src/components/NotchHud.vue` 的 scoped 樣式使用 `:global(html.dark) .notch-hud`，在 Vue 3.5 scoped CSS 編譯器下會被錯誤編成 `html.dark {}`——後代 `.notch-hud` 被丟棄。深色的 `--notch-*` 變數因此被設在 `<html>` 上，再被 `.notch-hud` 自身宣告的淺色 `--notch-*` 遮蔽（元素自身宣告優先於繼承值）。所以 notch 永遠拿到淺色值。此壞選擇器自 commit `c9437a5`（HUD 主題初版）即存在，HUD 深色從未生效過。

> 註：OS 偵測（Rust `get_os_theme` 讀登錄檔 `AppsUseLightTheme` + `theme:os-changed` 輪詢廣播）在 main 已正確實作、本身無誤；本問題純粹是 scoped CSS 選擇器的編譯 bug。

### 修正
改用 `html.dark .notch-hud`，編譯為 `html.dark .notch-hud[data-v]`，將深色變數直接設在 notch 元素上，正確覆蓋淺色基底。

### 影響檔案
- `src/components/NotchHud.vue`（單行選擇器）

### 關聯 Issue
N/A
