### PR TITLE
feat(models): backport #68 — model/API compatibility (Groq delisting hotfix)

### DIFF
--- a/src/lib/apiPricing.ts
+++ b/src/lib/apiPricing.ts
@@ -31,9 +31,11 @@ export function calculateChatCostCeiling(
   modelId: string = DEFAULT_LLM_MODEL_ID,
 ): number {
   const config = findLlmModelConfig(modelId);
+  // fallback 取全 registry 最貴的 outputCostPerMillion（gemini-3.5-flash $9/M），
+  // 維持「保證是上限」的不變量——查不到 config 時（如遺留的死 model id）不會低估
   const maxCostPerToken = config
     ? Math.max(config.inputCostPerMillion, config.outputCostPerMillion) /
       1_000_000
-    : 0.00000079;
+    : 0.000009;
   return totalTokens * maxCostPerToken;
 }

--- a/src/lib/hallucinationDetector.ts
+++ b/src/lib/hallucinationDetector.ts
@@ -86,6 +86,74 @@ export function detectEnhancementAnomaly(
   return { isAnomaly: false, reason: null };
 }
 
+// ── 增強後語意 grounding 偵測（#43）──
+
+/** 語意守衛：正規化後 rawText 至少要這麼長才判定（過短不可靠、交給 prompt） */
+export const SEMANTIC_DRIFT_MIN_RAW_CHARS = 6;
+/** 語意守衛門檻：enhanced 的 bigram 落在 raw 內的比例低於此值 → 判定「內容飄走」。
+ *  刻意設低（保守）：只擋「明顯不相干」，避免把合法的條列化/大幅改寫誤判成 drift。 */
+export const SEMANTIC_DRIFT_MIN_OVERLAP = 0.2;
+
+export interface SemanticDriftResult {
+  isDrift: boolean;
+  /** enhanced 的 bigram 有多少比例 grounded 在 raw（containment，0~1） */
+  overlapRatio: number;
+}
+
+/** 正規化：小寫化、去除空白與標點，只留字母/數字/CJK 等文字字元。 */
+function normalizeForOverlap(text: string): string {
+  return text.toLowerCase().replace(/[^\p{L}\p{N}]/gu, "");
+}
+
+function toBigramSet(text: string): Set<string> {
+  const set = new Set<string>();
+  for (let i = 0; i < text.length - 1; i += 1) {
+    set.add(text.slice(i, i + 2));
+  }
+  return set;
+}
+
+/**
+ * 增強後語意偏移偵測（#43 核心守衛）。
+ *
+ * 校對/整理的產出理應與原文高度重疊（同樣的字詞、只是修標點順句）；
+ * 若模型「答非所問」或自由發揮，產出會用完全不同的字詞 → bigram 幾乎不落在原文內。
+ * 用 enhanced→raw 的 bigram containment 當指標：長度差異不懲罰（raw 較長不影響），
+ * 只看「產出有多少 grounded 在原文」。門檻刻意保守、只擋明顯不相干。
+ *
+ * 注意：這是「長度爆炸」偵測之外的第二道、獨立的守衛；短輸入直接豁免。
+ */
+export function detectSemanticDrift(
+  rawText: string,
+  enhancedText: string,
+): SemanticDriftResult {
+  const raw = normalizeForOverlap(rawText);
+  const enhanced = normalizeForOverlap(enhancedText);
+
+  // 極短原文不可靠、或 enhanced 為空 → 不在此判定 drift（交給 prompt / 既有守衛）
+  if (raw.length < SEMANTIC_DRIFT_MIN_RAW_CHARS || enhanced.length === 0) {
+    return { isDrift: false, overlapRatio: 1 };
+  }
+
+  const rawBigrams = toBigramSet(raw);
+  const enhancedBigrams = toBigramSet(enhanced);
+  // 單字元（無 bigram 可比）保護
+  if (rawBigrams.size === 0 || enhancedBigrams.size === 0) {
+    return { isDrift: false, overlapRatio: 1 };
+  }
+
+  let grounded = 0;
+  for (const bigram of enhancedBigrams) {
+    if (rawBigrams.has(bigram)) grounded += 1;
+  }
+  const overlapRatio = grounded / enhancedBigrams.size;
+
+  return {
+    isDrift: overlapRatio < SEMANTIC_DRIFT_MIN_OVERLAP,
+    overlapRatio,
+  };
+}
+
 // ── 轉錄幻覺偵測 ──
 
 export function detectHallucination(

--- a/src/lib/llmProvider.ts
+++ b/src/lib/llmProvider.ts
@@ -214,7 +214,25 @@ function buildOpenAiCompatibleFetchParams(
     model: request.model,
     messages: request.messages,
   };
-  if (request.temperature !== undefined) body.temperature = request.temperature;
+  // OpenAI GPT-5.x 是推理模型：temperature 只接受預設值 1、送其他值回 400，
+  // 一律不送；改用 reasoning_effort 關閉推理（"none" 經實測 5.4-nano / 5.6-luna
+  // 皆接受；"minimal" 已被 5.6 世代移除、送出即 400）
+  if (providerId === "openai") {
+    body.reasoning_effort = "none";
+  } else if (request.temperature !== undefined) {
+    body.temperature = request.temperature;
+  }
+  if (providerId === "groq") {
+    if (request.model.startsWith("openai/gpt-oss")) {
+      // gpt-oss 預設產生推理內容：不回傳推理、推理強度最低（文字整理不需要）
+      body.include_reasoning = false;
+      body.reasoning_effort = "low";
+    } else if (request.model.startsWith("qwen/")) {
+      // Qwen3.x 預設開啟 <think> 思考模式；"none" 完全關閉（省時間與 token，
+      // 對 5 秒 timeout 至關重要）。content 端仍保留 stripReasoningTags 兜底
+      body.reasoning_effort = "none";
+    }
+  }
   if (request.maxTokens !== undefined) {
     // OpenAI GPT-5.x 系列要求 max_completion_tokens；Groq 仍用 max_tokens
     if (providerId === "openai") {
@@ -314,6 +332,11 @@ function buildGeminiFetchParams(
     generationConfig.temperature = request.temperature;
   if (request.maxTokens !== undefined)
     generationConfig.maxOutputTokens = request.maxTokens;
+  // Gemini 3.x 預設就會思考（medium）：文字整理不需要，壓到最低省延遲與 token。
+  // 欄位路徑與 enum 值出自 generateContent API 參考（ThinkingConfig.thinkingLevel）
+  if (request.model.startsWith("gemini-3")) {
+    generationConfig.thinkingConfig = { thinkingLevel: "MINIMAL" };
+  }
   if (Object.keys(generationConfig).length > 0)
     body.generationConfig = generationConfig;
 

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -7,15 +7,14 @@ export const DEFAULT_LLM_PROVIDER_ID: LlmProviderId = "groq";
 // ── LLM 模型（文字整理用）────────────────────────────────
 
 export type LlmModelId =
-  | "llama-3.3-70b-versatile"
-  | "meta-llama/llama-4-scout-17b-16e-instruct"
-  | "qwen/qwen3-32b"
-  | "gpt-5.4-mini"
+  | "qwen/qwen3.6-27b"
+  | "openai/gpt-oss-120b"
+  | "openai/gpt-oss-20b"
+  | "gpt-5.6-luna"
   | "gpt-5.4-nano"
   | "claude-haiku-4-5-20251001"
-  | "claude-3-5-haiku-20241022"
-  | "gemini-2.5-flash"
-  | "gemini-2.5-flash-lite";
+  | "gemini-3.5-flash"
+  | "gemini-3.1-flash-lite";
 
 // ── Whisper 模型（語音轉錄用）─────────────────────────────
 
@@ -48,22 +47,33 @@ export interface WhisperModelConfig {
 
 // ── 預設值 ────────────────────────────────────────────────
 
-export const DEFAULT_LLM_MODEL_ID: LlmModelId = "llama-3.3-70b-versatile";
+export const DEFAULT_LLM_MODEL_ID: LlmModelId = "qwen/qwen3.6-27b";
 export const DEFAULT_WHISPER_MODEL_ID: WhisperModelId = "whisper-large-v3";
 
 // ── 已下架模型 ID 映射（舊 → 新，用於自動遷移）──────────
+// 每個 value 必須是「當前 registry 內存活的 id」或「map 內另一個 key」
+// （getEffectiveLlmModelId 會迴圈解析、並保證回傳值存在於 registry）。
+// 映射原則：同 provider 內遷移，避免觸發 useSettingsStore 的 provider 交叉驗證。
 
-export const DECOMMISSIONED_MODEL_MAP: Record<string, LlmModelId> = {
-  "moonshotai/kimi-k2-instruct": "llama-3.3-70b-versatile",
-  "qwen-qwq-32b": "llama-3.3-70b-versatile",
-  "gpt-oss-120b": "llama-3.3-70b-versatile",
-  "openai/gpt-oss-120b": "llama-3.3-70b-versatile",
-  "openai/gpt-oss-20b": "llama-3.3-70b-versatile",
-  "llama-3.1-8b-instant": "qwen/qwen3-32b",
-  "llama-4-scout-17b-16e-instruct":
-    "meta-llama/llama-4-scout-17b-16e-instruct",
-  "llama-4-maverick-17b-128e-instruct": "qwen/qwen3-32b",
-  "meta-llama/llama-4-maverick-17b-128e-instruct": "qwen/qwen3-32b",
+export const DECOMMISSIONED_MODEL_MAP: Record<string, string> = {
+  // Groq — 2026-07-17 / 2026-08-16 下架潮
+  "llama-3.3-70b-versatile": "qwen/qwen3.6-27b",
+  "qwen/qwen3-32b": "qwen/qwen3.6-27b",
+  "qwen-qwq-32b": "qwen/qwen3.6-27b",
+  "moonshotai/kimi-k2-instruct": "qwen/qwen3.6-27b",
+  "meta-llama/llama-4-scout-17b-16e-instruct": "openai/gpt-oss-20b",
+  "llama-4-scout-17b-16e-instruct": "openai/gpt-oss-20b",
+  "llama-4-maverick-17b-128e-instruct": "qwen/qwen3.6-27b",
+  "meta-llama/llama-4-maverick-17b-128e-instruct": "qwen/qwen3.6-27b",
+  "llama-3.1-8b-instant": "openai/gpt-oss-20b",
+  "gpt-oss-120b": "openai/gpt-oss-120b",
+  // Gemini — 2.5 世代汰換
+  "gemini-2.5-flash": "gemini-3.5-flash",
+  "gemini-2.5-flash-lite": "gemini-3.1-flash-lite",
+  // OpenAI
+  "gpt-5.4-mini": "gpt-5.6-luna",
+  // Anthropic — 3.5 Haiku 已於 2026-02-19 退役
+  "claude-3-5-haiku-20241022": "claude-haiku-4-5-20251001",
 };
 
 // ── 模型清單 ──────────────────────────────────────────────
@@ -71,75 +81,76 @@ export const DECOMMISSIONED_MODEL_MAP: Record<string, LlmModelId> = {
 export const LLM_MODEL_LIST: LlmModelConfig[] = [
   // ── Groq（免費）──
   {
-    id: "llama-3.3-70b-versatile",
+    // Preview 模型：Groq 可無預警下架，顯示名稱標明讓使用者知情
+    id: "qwen/qwen3.6-27b",
     providerId: "groq",
-    displayName: "Llama 3.3 70B Versatile",
-    badgeKey: "settings.modelBadge.stableCostly",
-    speedTps: 280,
-    inputCostPerMillion: 0.59,
-    outputCostPerMillion: 0.79,
+    displayName: "Qwen3.6 27B (Preview)",
+    badgeKey: "settings.modelBadge.balanced",
+    speedTps: 500,
+    inputCostPerMillion: 0.6,
+    outputCostPerMillion: 3.0,
     freeQuotaRpd: 1_000,
-    freeQuotaTpd: 100_000,
+    freeQuotaTpd: 200_000,
     isDefault: true,
   },
   {
-    id: "qwen/qwen3-32b",
+    id: "openai/gpt-oss-120b",
     providerId: "groq",
-    displayName: "Qwen3 32B",
-    badgeKey: "settings.modelBadge.balanced",
-    speedTps: 400,
-    inputCostPerMillion: 0.29,
-    outputCostPerMillion: 0.59,
-    freeQuotaRpd: 1_000,
-    freeQuotaTpd: 500_000,
-    isDefault: false,
-  },
-  {
-    id: "meta-llama/llama-4-scout-17b-16e-instruct",
-    providerId: "groq",
-    displayName: "Llama 4 Scout 17B",
-    badgeKey: "settings.modelBadge.fastCheap",
-    speedTps: 750,
-    inputCostPerMillion: 0.11,
-    outputCostPerMillion: 0.34,
-    freeQuotaRpd: 1_000,
-    freeQuotaTpd: 500_000,
-    isDefault: false,
-  },
-  // ── Google Gemini（免費額度）──
-  {
-    id: "gemini-2.5-flash",
-    providerId: "gemini",
-    displayName: "Gemini 2.5 Flash",
-    badgeKey: "settings.modelBadge.balanced",
-    speedTps: 0,
+    displayName: "GPT OSS 120B",
+    badgeKey: "settings.modelBadge.stableCostly",
+    speedTps: 500,
     inputCostPerMillion: 0.15,
     outputCostPerMillion: 0.6,
-    freeQuotaRpd: 250,
+    freeQuotaRpd: 1_000,
+    freeQuotaTpd: 200_000,
+    isDefault: false,
+  },
+  {
+    id: "openai/gpt-oss-20b",
+    providerId: "groq",
+    displayName: "GPT OSS 20B",
+    badgeKey: "settings.modelBadge.fastCheap",
+    speedTps: 1_000,
+    inputCostPerMillion: 0.075,
+    outputCostPerMillion: 0.3,
+    freeQuotaRpd: 1_000,
+    freeQuotaTpd: 200_000,
+    isDefault: false,
+  },
+  // ── Google Gemini（免費額度依帳號而異，不在此顯示）──
+  {
+    id: "gemini-3.5-flash",
+    providerId: "gemini",
+    displayName: "Gemini 3.5 Flash",
+    badgeKey: "settings.modelBadge.premium",
+    speedTps: 0,
+    inputCostPerMillion: 1.5,
+    outputCostPerMillion: 9.0,
+    freeQuotaRpd: 0,
     freeQuotaTpd: 0,
     isDefault: true,
   },
   {
-    id: "gemini-2.5-flash-lite",
+    id: "gemini-3.1-flash-lite",
     providerId: "gemini",
-    displayName: "Gemini 2.5 Flash-Lite",
+    displayName: "Gemini 3.1 Flash-Lite",
     badgeKey: "settings.modelBadge.fastCheap",
     speedTps: 0,
-    inputCostPerMillion: 0.075,
-    outputCostPerMillion: 0.3,
-    freeQuotaRpd: 1_000,
+    inputCostPerMillion: 0.25,
+    outputCostPerMillion: 1.5,
+    freeQuotaRpd: 0,
     freeQuotaTpd: 0,
     isDefault: false,
   },
   // ── OpenAI（付費）──
   {
-    id: "gpt-5.4-mini",
+    id: "gpt-5.6-luna",
     providerId: "openai",
-    displayName: "GPT-5.4 Mini",
+    displayName: "GPT-5.6 Luna",
     badgeKey: "settings.modelBadge.premium",
     speedTps: 0,
-    inputCostPerMillion: 0.75,
-    outputCostPerMillion: 4.5,
+    inputCostPerMillion: 1.0,
+    outputCostPerMillion: 6.0,
     freeQuotaRpd: 0,
     freeQuotaTpd: 0,
     isDefault: true,
@@ -168,18 +179,6 @@ export const LLM_MODEL_LIST: LlmModelConfig[] = [
     freeQuotaRpd: 0,
     freeQuotaTpd: 0,
     isDefault: true,
-  },
-  {
-    id: "claude-3-5-haiku-20241022",
-    providerId: "anthropic",
-    displayName: "Claude 3.5 Haiku",
-    badgeKey: "settings.modelBadge.fastCheap",
-    speedTps: 0,
-    inputCostPerMillion: 0.8,
-    outputCostPerMillion: 4.0,
-    freeQuotaRpd: 0,
-    freeQuotaTpd: 0,
-    isDefault: false,
   },
 ];
 
@@ -228,17 +227,26 @@ export function getDefaultModelIdForProvider(
   return defaultModel?.id ?? providerModelList[0]?.id ?? DEFAULT_LLM_MODEL_ID;
 }
 
+// 遷移鏈解析上限：防止 map 內互指造成無窮迴圈
+const MAX_MIGRATION_HOPS = 5;
+
 /**
- * 安全取得 LLM 模型 ID：若 savedId 不在 registry 則嘗試自動遷移，
- * 遷移失敗則 fallback 到預設。處理舊版升級（null）和模型下架的情境。
+ * 安全取得 LLM 模型 ID：若 savedId 不在 registry 則沿遷移表迴圈解析，
+ * 解析失敗則 fallback 到預設。處理舊版升級（null）和模型下架的情境。
+ *
+ * 迴圈解析（而非單跳查找）是刻意的：歷次下架累積的舊 entry 可能指向
+ * 「後來也被下架」的模型，單跳會回傳 registry 查不到的死值，且下游
+ * provider 交叉驗證對 undefined config 短路、救不回來。此函式保證
+ * 回傳值必存在於當前 registry。
  */
 export function getEffectiveLlmModelId(savedId: string | null): LlmModelId {
-  if (savedId && findLlmModelConfig(savedId)) return savedId as LlmModelId;
-
-  if (savedId && savedId in DECOMMISSIONED_MODEL_MAP) {
-    return DECOMMISSIONED_MODEL_MAP[savedId];
+  let candidate = savedId;
+  for (let hop = 0; candidate && hop < MAX_MIGRATION_HOPS; hop += 1) {
+    if (findLlmModelConfig(candidate)) return candidate as LlmModelId;
+    const next: string | undefined = DECOMMISSIONED_MODEL_MAP[candidate];
+    if (!next) break;
+    candidate = next;
   }
-
   return DEFAULT_LLM_MODEL_ID;
 }
 

--- a/tests/component/DashboardView.test.ts
+++ b/tests/component/DashboardView.test.ts
@@ -56,7 +56,7 @@ function makeSettings(overrides: Record<string, unknown> = {}) {
     whisperProviderId: "groq",
     selectedLlmProviderId: "groq",
     selectedWhisperModelId: "whisper-large-v3",
-    selectedLlmModelId: "llama-3.3-70b-versatile",
+    selectedLlmModelId: "qwen/qwen3.6-27b",
     ...overrides,
   };
 }

--- a/tests/unit/api-pricing.test.ts
+++ b/tests/unit/api-pricing.test.ts
@@ -56,22 +56,22 @@ describe("apiPricing.ts", () => {
     });
 
     it("[P0] 1000 tokens 應按 output 價格上限計算", () => {
-      // 預設模型 Llama 3.3 70B: max(input=0.59, output=0.79) = 0.79/M
-      // 1000 * 0.00000079 = 0.00079
+      // 預設模型 Qwen3.6 27B: max(input=0.6, output=3.0) = 3.0/M
+      // 1000 * 0.000003 = 0.003
       const cost = calculateChatCostCeiling(1000);
-      expect(cost).toBeCloseTo(0.00079, 6);
+      expect(cost).toBeCloseTo(0.003, 6);
     });
 
-    it("[P0] 1M tokens 應回傳 $0.79", () => {
-      // 預設模型 Llama 3.3 70B: 1M * 0.79/M = 0.79
+    it("[P0] 1M tokens 應回傳 $3.00", () => {
+      // 預設模型 Qwen3.6 27B: 1M * 3.0/M = 3.0
       const cost = calculateChatCostCeiling(1_000_000);
-      expect(cost).toBeCloseTo(0.79, 4);
+      expect(cost).toBeCloseTo(3.0, 4);
     });
 
     it("[P1] 150 tokens 應正確計算", () => {
-      // 預設模型 Llama 3.3 70B: 150 * 0.00000079 = 0.0001185
+      // 預設模型 Qwen3.6 27B: 150 * 0.000003 = 0.00045
       const cost = calculateChatCostCeiling(150);
-      expect(cost).toBeCloseTo(0.0001185, 6);
+      expect(cost).toBeCloseTo(0.00045, 6);
     });
   });
 });

--- a/tests/unit/enhancer.test.ts
+++ b/tests/unit/enhancer.test.ts
@@ -116,7 +116,7 @@ describe("enhancer.ts", () => {
       expect(callArgs[1].headers.Authorization).toBe(`Bearer ${TEST_API_KEY}`);
 
       const body = JSON.parse(callArgs[1].body);
-      expect(body.model).toBe("llama-3.3-70b-versatile");
+      expect(body.model).toBe("qwen/qwen3.6-27b");
       expect(body.temperature).toBe(0.1);
       expect(body.max_tokens).toBe(8192);
       expect(body.messages).toHaveLength(2);

--- a/tests/unit/hallucination-detector.test.ts
+++ b/tests/unit/hallucination-detector.test.ts
@@ -9,6 +9,8 @@ import {
   SILENCE_NSP_THRESHOLD,
   LAYER2B_PEAK_ENERGY_CEILING,
   ENHANCEMENT_LENGTH_EXPLOSION_RATIO,
+  detectSemanticDrift,
+  SEMANTIC_DRIFT_MIN_OVERLAP,
 } from "../../src/lib/hallucinationDetector";
 
 /** 正常語音的預設參數（Layer 1/2 都不觸發） */
@@ -388,6 +390,45 @@ describe("hallucinationDetector.ts", () => {
 
       // 都返回 "no-speech-detected"，不需要區分子原因
       expect(result.reason).toBe("no-speech-detected");
+    });
+  });
+
+  describe("detectSemanticDrift（#43 語意守衛）", () => {
+    it("[P0] 正常校對（同內容加標點）不應判定 drift", () => {
+      const r = detectSemanticDrift(
+        "我明天要去公司開會然後下午回家",
+        "我明天要去公司開會，然後下午回家。",
+      );
+      expect(r.isDrift).toBe(false);
+      expect(r.overlapRatio).toBeGreaterThan(0.8);
+    });
+
+    it("[P0] 去口語贅字的校對不應判定 drift", () => {
+      const r = detectSemanticDrift(
+        "呃我想說我們明天要不要約個時間開會討論一下",
+        "我想我們明天要約時間開會討論一下",
+      );
+      expect(r.isDrift).toBe(false);
+    });
+
+    it("[P0] 答非所問／內容不相干應判定 drift", () => {
+      const r = detectSemanticDrift(
+        "今天天氣真好想出去走走曬曬太陽",
+        "好的請問有什麼可以幫您的嗎",
+      );
+      expect(r.isDrift).toBe(true);
+      expect(r.overlapRatio).toBeLessThan(SEMANTIC_DRIFT_MIN_OVERLAP);
+    });
+
+    it("[P0] 極短原文（< 6 字）豁免、不判定 drift", () => {
+      const r = detectSemanticDrift("現在幾點", "現在是下午三點整");
+      expect(r.isDrift).toBe(false);
+    });
+
+    it("[P1] enhanced 為空不判定 drift", () => {
+      expect(detectSemanticDrift("我要去開會討論專案進度", "").isDrift).toBe(
+        false,
+      );
     });
   });
 });

--- a/tests/unit/llmProvider.test.ts
+++ b/tests/unit/llmProvider.test.ts
@@ -60,6 +60,60 @@ describe("llmProvider.ts", () => {
       expect(body.max_tokens).toBeUndefined();
     });
 
+    it("[P0] OpenAI：推理模型不送 temperature、改送 reasoning_effort:none（修 400）", () => {
+      const { init } = buildFetchParams("openai", BASE_REQUEST, TEST_API_KEY);
+      const body = JSON.parse(init.body as string);
+      expect(body.reasoning_effort).toBe("none");
+      expect(body.temperature).toBeUndefined();
+    });
+
+    it("[P0] Groq gpt-oss：抑制推理（include_reasoning:false + reasoning_effort:low）", () => {
+      const { init } = buildFetchParams(
+        "groq",
+        { ...BASE_REQUEST, model: "openai/gpt-oss-120b" },
+        TEST_API_KEY,
+      );
+      const body = JSON.parse(init.body as string);
+      expect(body.include_reasoning).toBe(false);
+      expect(body.reasoning_effort).toBe("low");
+      expect(body.temperature).toBe(0.1);
+    });
+
+    it("[P0] Groq qwen：關閉思考（reasoning_effort:none）但仍送 temperature", () => {
+      const { init } = buildFetchParams(
+        "groq",
+        { ...BASE_REQUEST, model: "qwen/qwen3.6-27b" },
+        TEST_API_KEY,
+      );
+      const body = JSON.parse(init.body as string);
+      expect(body.reasoning_effort).toBe("none");
+      expect(body.temperature).toBe(0.1);
+    });
+
+    it("[P1] Groq 非推理模型：不加 reasoning 欄位、照常送 temperature", () => {
+      const { init } = buildFetchParams("groq", BASE_REQUEST, TEST_API_KEY);
+      const body = JSON.parse(init.body as string);
+      expect(body.reasoning_effort).toBeUndefined();
+      expect(body.include_reasoning).toBeUndefined();
+      expect(body.temperature).toBe(0.1);
+    });
+
+    it("[P0] Gemini 3.x：thinkingConfig.thinkingLevel=MINIMAL", () => {
+      const { init } = buildFetchParams(
+        "gemini",
+        { ...BASE_REQUEST, model: "gemini-3.5-flash" },
+        TEST_API_KEY,
+      );
+      const body = JSON.parse(init.body as string);
+      expect(body.generationConfig.thinkingConfig.thinkingLevel).toBe("MINIMAL");
+    });
+
+    it("[P1] Gemini 非-3 模型：不加 thinkingConfig", () => {
+      const { init } = buildFetchParams("gemini", BASE_REQUEST, TEST_API_KEY);
+      const body = JSON.parse(init.body as string);
+      expect(body.generationConfig.thinkingConfig).toBeUndefined();
+    });
+
     it("[P0] Anthropic：正確 URL、x-api-key header、anthropic-version header", () => {
       const { url, init } = buildFetchParams("anthropic", BASE_REQUEST, TEST_API_KEY);
 

--- a/tests/unit/llmProvider.test.ts
+++ b/tests/unit/llmProvider.test.ts
@@ -298,10 +298,10 @@ describe("llmProvider.ts", () => {
     });
 
     it("[P0] getProviderIdForModel 根據 modelId 回傳 providerId", () => {
-      expect(getProviderIdForModel("llama-3.3-70b-versatile")).toBe("groq");
-      expect(getProviderIdForModel("gpt-5.4-mini")).toBe("openai");
+      expect(getProviderIdForModel("qwen/qwen3.6-27b")).toBe("groq");
+      expect(getProviderIdForModel("gpt-5.6-luna")).toBe("openai");
       expect(getProviderIdForModel("claude-haiku-4-5-20251001")).toBe("anthropic");
-      expect(getProviderIdForModel("gemini-2.5-flash")).toBe("gemini");
+      expect(getProviderIdForModel("gemini-3.5-flash")).toBe("gemini");
     });
 
     it("[P1] getProviderIdForModel 未知模型 fallback 到 groq", () => {

--- a/tests/unit/model-registry.test.ts
+++ b/tests/unit/model-registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  DECOMMISSIONED_MODEL_MAP,
+  DEFAULT_LLM_MODEL_ID,
+  getEffectiveLlmModelId,
+  findLlmModelConfig,
+} from "../../src/lib/modelRegistry";
+
+describe("modelRegistry — 模型遷移", () => {
+  describe("DECOMMISSIONED_MODEL_MAP 不變量", () => {
+    it("[P0] 每個 legacy id 最終都解析到 registry 內存活的模型（無死值）", () => {
+      for (const legacyId of Object.keys(DECOMMISSIONED_MODEL_MAP)) {
+        const resolved = getEffectiveLlmModelId(legacyId);
+        expect(
+          findLlmModelConfig(resolved),
+          `${legacyId} → ${resolved} 不在 registry`,
+        ).toBeDefined();
+      }
+    });
+
+    it("[P0] 預設模型本身存在於 registry", () => {
+      expect(findLlmModelConfig(DEFAULT_LLM_MODEL_ID)).toBeDefined();
+    });
+  });
+
+  describe("getEffectiveLlmModelId", () => {
+    it("[P0] registry 內的 id 原樣返回", () => {
+      expect(getEffectiveLlmModelId(DEFAULT_LLM_MODEL_ID)).toBe(
+        DEFAULT_LLM_MODEL_ID,
+      );
+      expect(getEffectiveLlmModelId("openai/gpt-oss-120b")).toBe(
+        "openai/gpt-oss-120b",
+      );
+    });
+
+    it("[P0] 已下架的舊預設 llama-3.3-70b 遷移到新預設", () => {
+      expect(getEffectiveLlmModelId("llama-3.3-70b-versatile")).toBe(
+        "qwen/qwen3.6-27b",
+      );
+    });
+
+    it("[P0] 07-17 下架的 scout / qwen3-32b 遷移到存活模型", () => {
+      expect(
+        findLlmModelConfig(
+          getEffectiveLlmModelId("meta-llama/llama-4-scout-17b-16e-instruct"),
+        ),
+      ).toBeDefined();
+      expect(
+        findLlmModelConfig(getEffectiveLlmModelId("qwen/qwen3-32b")),
+      ).toBeDefined();
+    });
+
+    it("[P0] null（舊版升級）→ 預設", () => {
+      expect(getEffectiveLlmModelId(null)).toBe(DEFAULT_LLM_MODEL_ID);
+    });
+
+    it("[P0] 完全未知的 id → 預設", () => {
+      expect(getEffectiveLlmModelId("totally-made-up-model")).toBe(
+        DEFAULT_LLM_MODEL_ID,
+      );
+    });
+  });
+});

--- a/tests/unit/use-history-retry.test.ts
+++ b/tests/unit/use-history-retry.test.ts
@@ -17,7 +17,7 @@ const h = vi.hoisted(() => {
     refreshLlmApiKey: vi.fn(),
     getLlmRequestConfig: vi.fn(),
     getAiPrompt: () => "prompt",
-    getEffectiveChatModel: () => "llama-3.3-70b-versatile",
+    getEffectiveChatModel: () => "qwen/qwen3.6-27b",
   };
   return {
     mockDbExecute,
@@ -98,7 +98,7 @@ describe("useHistoryStore retry", () => {
     h.settingsStub.getLlmRequestConfig.mockReset().mockResolvedValue({
       apiKey: "llm-key",
       provider: "groq",
-      modelId: "llama-3.3-70b-versatile",
+      modelId: "qwen/qwen3.6-27b",
     });
   });
 

--- a/tests/unit/use-history-store.test.ts
+++ b/tests/unit/use-history-store.test.ts
@@ -972,7 +972,7 @@ describe("useHistoryStore", () => {
         id: "usage-002",
         transcriptionId: "tx-001",
         apiType: "chat",
-        model: "llama-3.3-70b-versatile",
+        model: "qwen/qwen3.6-27b",
         promptTokens: 100,
         completionTokens: 50,
         totalTokens: 150,

--- a/tests/unit/use-settings-store.test.ts
+++ b/tests/unit/use-settings-store.test.ts
@@ -418,7 +418,7 @@ describe("useSettingsStore", () => {
       mockStoreData.set("promptMode", "custom");
       mockStoreData.set("enhancementThresholdEnabled", true);
       mockStoreData.set("enhancementThresholdCharCount", 42);
-      mockStoreData.set("llmModelId", "llama-3.3-70b-versatile");
+      mockStoreData.set("llmModelId", "openai/gpt-oss-120b");
       mockStoreData.set("whisperModelId", "whisper-large-v3-turbo");
       mockStoreData.set("muteOnRecording", false);
 
@@ -439,7 +439,7 @@ describe("useSettingsStore", () => {
       expect(store.getAiPrompt()).toBe("同步後 prompt");
       expect(store.isEnhancementThresholdEnabled).toBe(true);
       expect(store.enhancementThresholdCharCount).toBe(42);
-      expect(store.selectedLlmModelId).toBe("llama-3.3-70b-versatile");
+      expect(store.selectedLlmModelId).toBe("openai/gpt-oss-120b");
       expect(store.selectedWhisperModelId).toBe("whisper-large-v3-turbo");
       expect(store.isMuteOnRecordingEnabled).toBe(false);
     });

--- a/tests/unit/use-voice-flow-store.test.ts
+++ b/tests/unit/use-voice-flow-store.test.ts
@@ -86,7 +86,7 @@ const {
       triggerMode: "hold" as string,
       isEnhancementThresholdEnabled: true,
       enhancementThresholdCharCount: 10,
-      selectedLlmModelId: "llama-3.3-70b-versatile",
+      selectedLlmModelId: "qwen/qwen3.6-27b",
       selectedWhisperModelId: "whisper-large-v3",
       isMuteOnRecordingEnabled: false,
       isSoundEffectsEnabled: true,
@@ -335,7 +335,7 @@ describe("useVoiceFlowStore", () => {
     mockSettingsState.triggerMode = "hold";
     mockSettingsState.isEnhancementThresholdEnabled = true;
     mockSettingsState.enhancementThresholdCharCount = 10;
-    mockSettingsState.selectedLlmModelId = "llama-3.3-70b-versatile";
+    mockSettingsState.selectedLlmModelId = "qwen/qwen3.6-27b";
     mockSettingsState.selectedWhisperModelId = "whisper-large-v3";
     mockSettingsState.isMuteOnRecordingEnabled = false;
     mockSettingsState.isSoundEffectsEnabled = true;
@@ -1439,7 +1439,7 @@ describe("useVoiceFlowStore", () => {
         "test-api-key-123",
         expect.objectContaining({
           vocabularyTermList: ["Pinia", "Vitest"],
-          modelId: "llama-3.3-70b-versatile",
+          modelId: "qwen/qwen3.6-27b",
         }),
       );
     });
@@ -1964,7 +1964,7 @@ describe("useVoiceFlowStore", () => {
 
       const chatRecord = mockAddApiUsage.mock.calls[1][0];
       expect(chatRecord.apiType).toBe("chat");
-      expect(chatRecord.model).toBe("llama-3.3-70b-versatile");
+      expect(chatRecord.model).toBe("qwen/qwen3.6-27b");
       expect(chatRecord.promptTokens).toBe(100);
       expect(chatRecord.completionTokens).toBe(50);
       expect(chatRecord.totalTokens).toBe(150);


### PR DESCRIPTION
## 為什麼（urgent）
Groq 進入 2026-07 下架潮：本 fork 目前提供的 3 顆 Groq 模型有 **2 顆在 2026-07-17（約 4 天內）下架**（`meta-llama/llama-4-scout-17b-16e-instruct`、`qwen/qwen3-32b`），預設的 `llama-3.3-70b-versatile` 也將在 **2026-08-16** 下架。更糟的是原本的 `DECOMMISSIONED_MODEL_MAP` 反而把 legacy id 導向即將下架的模型、且無 fallback。此 PR 回收上游 `chenjackle45/SayIt#68` 的模型/API 相容性整包，趕在下架前保住預設與既有使用者。

## 做了什麼
- **modelRegistry**：Groq 換成 `qwen/qwen3.6-27b`（新預設）＋ `openai/gpt-oss-120b/20b`；Gemini → 3.x；OpenAI → `gpt-5.6-luna`；移除已退役的 `claude-3-5-haiku`。`DECOMMISSIONED_MODEL_MAP` 改寫為**多跳解析（含 hop 上限）**，保證 legacy 存檔 id 不會解析到已死模型。
- **llmProvider**：OpenAI GPT-5.x 改送 `reasoning_effort:"none"`（不再送 temperature，修 400）；Groq `gpt-oss` 抑制推理、Qwen3.x `none`；Gemini 3.x `thinkingLevel:"MINIMAL"`。
- **apiPricing**：未知模型的費用上限 fallback 調高到 registry 內最貴費率。
- **anomaly**：新增 `detectSemanticDrift`（#68 內的 #43 語意守衛，bigram containment），偵測「答非所問」的 LLM 產出。**目前為函式＋測試**，wiring 進 enhance/retry 路徑留待 #60/A2 backport。

## 保留 / 不動
- ✅ **保留 fork 專屬的 `azure` / Microsoft Foundry provider**（上游無此 provider）。
- ❌ **未回收 `errorUtils`**（fork 版的 Tauri 字串／Azure-aware 處理更完整）。

## 分歧說明
上游 `modelRegistry.ts` 已與本 fork 分歧 158 行，故採**手動移植**而非 cherry-pick。

## 合併前 Release Gate（⚠️ 需人工）
- [ ] 以**真實 API key** 對每顆替換模型做 live smoke call（新預設 `qwen/qwen3.6-27b` 為 Groq Preview 模型，需確認實際可用）
- [ ] 已持久化舊 model id 的 migration 驗證（確保被正確 remap、且不 remap 到已下架者）
- [ ] 版本號同步四處（package.json / tauri.conf.json / Cargo.toml / tag）並發 fork release（建議 07-17 前）

Refs upstream chenjackle45/SayIt#68