### PR TITLE
fix(dashboard,models): complete #68 backport — Gemini usage + resolver hardening

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -313,7 +313,8 @@
     "billedPlan": "Billed",
     "billedNoFreeQuota": "Pay-as-you-go — no free quota limit",
     "usageWhisper": "Whisper: {requests} req · {audio}",
-    "usageLlm": "LLM: {requests} req · {tokens} tokens"
+    "usageLlm": "LLM: {requests} req · {tokens} tokens",
+    "geminiQuotaHint": "Gemini free quota varies by account; check it in Google AI Studio"
   },
   "history": {
     "searchPlaceholder": "Search transcriptions...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -313,7 +313,8 @@
     "billedPlan": "従量課金",
     "billedNoFreeQuota": "従量課金 — 無料枠なし",
     "usageWhisper": "Whisper：{requests} 回 · {audio}",
-    "usageLlm": "LLM：{requests} 回 · {tokens} tokens"
+    "usageLlm": "LLM：{requests} 回 · {tokens} tokens",
+    "geminiQuotaHint": "Gemini の無料枠はアカウントにより変動し、Google AI Studio で確認できます"
   },
   "history": {
     "searchPlaceholder": "文字起こし履歴を検索...",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -313,7 +313,8 @@
     "billedPlan": "유료",
     "billedNoFreeQuota": "유료 요금제 — 무료 할당량 없음",
     "usageWhisper": "Whisper: {requests}회 · {audio}",
-    "usageLlm": "LLM: {requests}회 · {tokens} tokens"
+    "usageLlm": "LLM: {requests}회 · {tokens} tokens",
+    "geminiQuotaHint": "Gemini 무료 할당량은 계정에 따라 다르며 Google AI Studio에서 확인할 수 있습니다"
   },
   "history": {
     "searchPlaceholder": "전사 기록 검색...",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -313,7 +313,8 @@
     "billedPlan": "计费",
     "billedNoFreeQuota": "付费方案 — 无免费额度限制",
     "usageWhisper": "Whisper：{requests} 次 · {audio}",
-    "usageLlm": "LLM：{requests} 次 · {tokens} tokens"
+    "usageLlm": "LLM：{requests} 次 · {tokens} tokens",
+    "geminiQuotaHint": "Gemini 免费额度依账号浮动，仅能于 Google AI Studio 查询"
   },
   "history": {
     "searchPlaceholder": "搜索转录记录...",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -313,7 +313,8 @@
     "billedPlan": "計費",
     "billedNoFreeQuota": "付費方案 — 無免費額度限制",
     "usageWhisper": "Whisper：{requests} 次 · {audio}",
-    "usageLlm": "LLM：{requests} 次 · {tokens} tokens"
+    "usageLlm": "LLM：{requests} 次 · {tokens} tokens",
+    "geminiQuotaHint": "Gemini 免費額度依帳號浮動，僅能於 Google AI Studio 查詢"
   },
   "history": {
     "searchPlaceholder": "搜尋轉錄記錄...",

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -247,6 +247,8 @@ export function getEffectiveLlmModelId(savedId: string | null): LlmModelId {
     if (!next) break;
     candidate = next;
   }
+  // 迴圈上限用盡後，最後一跳的結果仍可能是存活模型 → 補驗一次（避免 off-by-one 誤退預設）
+  if (candidate && findLlmModelConfig(candidate)) return candidate as LlmModelId;
   return DEFAULT_LLM_MODEL_ID;
 }
 

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -59,6 +59,15 @@ const hasAnyPaidProvider = computed(
   () => isPaidWhisperProvider.value || isPaidLlmProvider.value,
 );
 
+// Gemini 免費額度已不公開（依帳號浮動、僅能在 Google AI Studio 查詢）：
+// registry 將其 freeQuotaRpd 設 0 → 額度條自動略過，改以「今日用量」呈現。
+// Azure 等計費 provider 由 isPaidLlmProvider 短路排除。
+const isQuotaHiddenLlmProvider = computed(() => {
+  if (isPaidLlmProvider.value) return false;
+  const lConfig = findLlmModelConfig(settingsStore.selectedLlmModelId);
+  return (lConfig?.freeQuotaRpd ?? 0) === 0;
+});
+
 const quotaDimensionList = computed(() => {
   const usage = historyStore.dashboardStats.dailyQuotaUsage;
   const dimensionList: { remaining: number; label: string }[] = [];
@@ -119,7 +128,7 @@ const paidUsageList = computed(() => {
       }),
     });
   }
-  if (isPaidLlmProvider.value) {
+  if (isPaidLlmProvider.value || isQuotaHiddenLlmProvider.value) {
     list.push({
       label: t("dashboard.usageLlm", {
         requests: formatNumber(usage.llmRequestCount),
@@ -262,6 +271,14 @@ onBeforeUnmount(() => {
                   </p>
                 </template>
 
+                <!-- Gemini 免費額度不公開：說明無額度條、僅顯示今日用量 -->
+                <p
+                  v-if="isQuotaHiddenLlmProvider"
+                  class="text-xs text-muted-foreground mt-1.5"
+                >
+                  {{ $t("dashboard.geminiQuotaHint") }}
+                </p>
+
                 <!-- 付費服務今日用量（混用與全付費共用同一段；混用為次要樣式 + 分隔線）-->
                 <div
                   v-if="paidUsageList.length > 0"
@@ -305,6 +322,14 @@ onBeforeUnmount(() => {
               </div>
             </div>
             <div
+              v-if="isQuotaHiddenLlmProvider"
+              class="mt-2 pt-2 border-t border-border"
+            >
+              <span class="text-xs text-muted-foreground">
+                {{ $t("dashboard.geminiQuotaHint") }}
+              </span>
+            </div>
+            <div
               v-if="paidUsageList.length > 0"
               class="space-y-1"
               :class="{ 'mt-2 pt-2 border-t border-border': hasFreeQuota }"
@@ -316,7 +341,7 @@ onBeforeUnmount(() => {
               >
                 {{ item.label }}
               </div>
-              <p class="text-xs text-muted-foreground">{{ $t("dashboard.billedNoFreeQuota") }}</p>
+              <p v-if="hasAnyPaidProvider" class="text-xs text-muted-foreground">{{ $t("dashboard.billedNoFreeQuota") }}</p>
             </div>
             <div
               v-if="historyStore.dashboardStats.dailyQuotaUsage.vocabularyAnalysisRequestCount > 0"

--- a/tests/component/DashboardView.test.ts
+++ b/tests/component/DashboardView.test.ts
@@ -96,6 +96,27 @@ describe("DashboardView 額度卡片", () => {
     expect(text).not.toContain("今日用量");
   });
 
+  it("[P0] Gemini（免費額度不公開）：主體顯示 LLM 今日用量與提示，不誤標付費方案", () => {
+    settingsState = makeSettings({
+      selectedLlmProviderId: "gemini",
+      selectedLlmModelId: "gemini-3.5-flash",
+    });
+    historyState = makeHistory({
+      whisperRequestCount: 10,
+      llmRequestCount: 6,
+      llmTotalTokens: 3200,
+    });
+    const text = mountDashboard().text();
+
+    // Gemini LLM 用量以「今日用量」呈現（回歸前 quota=0 會讓它完全消失）
+    expect(text).toContain("LLM：6 次 · 3,200 tokens");
+    expect(text).toContain("Gemini 免費額度依帳號浮動");
+    // Gemini 非付費方案 → 不得出現「付費方案 — 無免費額度限制」
+    expect(text).not.toContain("付費方案 — 無免費額度限制");
+    expect(text).not.toContain("Infinity");
+    expect(text).not.toContain("NaN");
+  });
+
   it("[P0] 全計費 provider（Azure）：主體顯示今日用量與計費提示，不顯示百分比", () => {
     settingsState = makeSettings({
       whisperProviderId: "azure",

--- a/tests/unit/model-registry.test.ts
+++ b/tests/unit/model-registry.test.ts
@@ -8,12 +8,31 @@ import {
 
 describe("modelRegistry — 模型遷移", () => {
   describe("DECOMMISSIONED_MODEL_MAP 不變量", () => {
-    it("[P0] 每個 legacy id 最終都解析到 registry 內存活的模型（無死值）", () => {
-      for (const legacyId of Object.keys(DECOMMISSIONED_MODEL_MAP)) {
-        const resolved = getEffectiveLlmModelId(legacyId);
+    it("[P0] 每個 map value 是存活模型或另一個 map key（結構不變量，抓 typo）", () => {
+      for (const [key, value] of Object.entries(DECOMMISSIONED_MODEL_MAP)) {
+        const isLiveModel = findLlmModelConfig(value) !== undefined;
+        const isAnotherKey = value in DECOMMISSIONED_MODEL_MAP;
         expect(
-          findLlmModelConfig(resolved),
-          `${legacyId} → ${resolved} 不在 registry`,
+          isLiveModel || isAnotherKey,
+          `${key} → ${value}: value 既非存活模型也非另一個 map key（可能是 typo）`,
+        ).toBe(true);
+      }
+    });
+
+    it("[P0] 每條遷移鏈無環且終點為存活模型", () => {
+      for (const startKey of Object.keys(DECOMMISSIONED_MODEL_MAP)) {
+        const seen = new Set<string>();
+        let cur: string | undefined = startKey;
+        while (cur && !findLlmModelConfig(cur)) {
+          expect(seen.has(cur), `遷移鏈出現環：${startKey} … ${cur}`).toBe(
+            false,
+          );
+          seen.add(cur);
+          cur = DECOMMISSIONED_MODEL_MAP[cur];
+        }
+        expect(
+          cur ? findLlmModelConfig(cur) : undefined,
+          `${startKey} 的遷移鏈終點不是存活模型`,
         ).toBeDefined();
       }
     });


### PR DESCRIPTION
Follow-up to #18. Self-review (Council + RubberDuck) found the #68 model/API backport was **incomplete on the Dashboard side**, plus two latent issues.

## Fixes
- **Gemini usage disappeared (regression from #18)** — #68 zeroed Gemini free quota in the registry, but the matching `DashboardView` handling (`isQuotaHiddenLlmProvider`) was never ported, so Gemini LLM usage showed neither a quota bar nor a billed-usage row → completely invisible. Now rendered as "today''s usage" with a `geminiQuotaHint` (5 locales); the tooltip billed/no-free-quota line is guarded behind `hasAnyPaidProvider` so Gemini is never mislabeled as a paid plan.
- **Migration resolver off-by-one** — `getEffectiveLlmModelId` fell through to the default when a chain resolved on the 5th hop. Added a post-loop check (latent; current map is single-hop).
- **Weak invariant test** — the previous test could not catch a typo''d map value (resolver always falls back to a valid default). Replaced with a structural check (every value is a live model or another key) + chain-termination/no-cycle check; added a Gemini Dashboard regression test.

## Validation
`npx vue-tsc --noEmit` ✅ · `pnpm exec eslint src` ✅ · `pnpm exec vitest run --no-file-parallelism` → **550 passing**.

Refs upstream chenjackle45/SayIt#68
