### PR TITLE
feat(transcription): auto-retry on 429/5xx/connection failures (#10)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4918,6 +4918,7 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "thiserror 2.0.18",
+ "tokio",
  "windows 0.61.3",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ cpal = "0.15"
 hound = "3.5"
 rustfft = "6"
 reqwest = { version = "0.12", features = ["multipart", "json", "rustls-tls", "rustls-tls-native-roots"] }
+tokio = { version = "1", features = ["time"] }
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-log = "2.8.0"
 log = "0.4.33"

--- a/src-tauri/src/plugins/transcription.rs
+++ b/src-tauri/src/plugins/transcription.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tauri::{command, State};
 
@@ -150,6 +150,204 @@ fn build_azure_whisper_config(
 
 // ========== Shared Transcription Logic ==========
 
+// ========== Retry Classification (gh-10) ==========
+
+/// gh-10：429/5xx/連線失敗自動重試（初次 + 2 次重試）
+const MAX_TRANSCRIPTION_ATTEMPTS: u32 = 3;
+/// 各次重試前的固定等待秒數（無 Retry-After 提示時）
+const RETRY_BACKOFF_SECS: [u64; 2] = [1, 2];
+/// Retry-After 建議等待超過此上限就直接放棄——語音場景等太久不如早報錯
+const MAX_RETRY_AFTER_WAIT_SECS: u64 = 10;
+
+/// 單次嘗試的失敗分類——決定要不要重試
+enum FailureKind {
+    /// HTTP 429，帶 Retry-After 建議秒數（若可解析）
+    RateLimited { retry_after_secs: Option<u64> },
+    /// HTTP 5xx
+    ServerError,
+    /// 連線建立失敗（fail-fast 型，重試便宜）
+    Connect,
+    /// 4xx／timeout／parse 等——重試無意義或代價過高
+    NoRetry,
+}
+
+struct AttemptFailure {
+    error: TranscriptionError,
+    kind: FailureKind,
+}
+
+fn failure_kind_label(kind: &FailureKind) -> &'static str {
+    match kind {
+        FailureKind::RateLimited { .. } => "rate-limited",
+        FailureKind::ServerError => "server-error",
+        FailureKind::Connect => "connect-failed",
+        FailureKind::NoRetry => "no-retry",
+    }
+}
+
+/// 只支援 Retry-After 的秒數格式；HTTP-date 格式解析失敗回 None（退回固定 backoff）
+fn parse_retry_after_secs(value: Option<&str>) -> Option<u64> {
+    value?.trim().parse::<u64>().ok()
+}
+
+/// 回傳 Some(等待秒數) = 該重試；None = 直接放棄。attempt 為剛失敗的嘗試序號（1-based）
+fn retry_wait_secs(kind: &FailureKind, attempt: u32) -> Option<u64> {
+    let backoff_index = (attempt as usize)
+        .saturating_sub(1)
+        .min(RETRY_BACKOFF_SECS.len() - 1);
+    let backoff = RETRY_BACKOFF_SECS[backoff_index];
+    match kind {
+        FailureKind::RateLimited { retry_after_secs } => {
+            let wait = retry_after_secs.unwrap_or(backoff);
+            if wait > MAX_RETRY_AFTER_WAIT_SECS {
+                None
+            } else {
+                Some(wait)
+            }
+        }
+        FailureKind::ServerError | FailureKind::Connect => Some(backoff),
+        FailureKind::NoRetry => None,
+    }
+}
+
+// ========== Shared Transcription Logic ==========
+
+/// 依 provider 決定 URL、是否帶 model 欄位、與認證 header 型式。跨重試不變、解析一次即可。
+fn resolve_transcription_endpoint(azure: &Option<AzureWhisperConfig>) -> (String, bool, bool) {
+    match azure {
+        Some(cfg) => {
+            let base = cfg.endpoint.trim_end_matches('/');
+            (
+                format!(
+                    "{}/openai/deployments/{}/audio/transcriptions?api-version={}",
+                    base, cfg.deployment, cfg.api_version
+                ),
+                cfg.use_bearer,
+                false,
+            )
+        }
+        None => (GROQ_API_URL.to_string(), true, true),
+    }
+}
+
+/// 單次 API 嘗試：建 form → 送出 → 解析。回傳 (raw_text, no_speech_probability)。
+/// URL / 認證 / 是否帶 model 由呼叫端解析一次後傳入（跨重試不變）。
+#[allow(clippy::too_many_arguments)]
+async fn attempt_transcription_request(
+    wav_data: Vec<u8>,
+    transcription_state: &TranscriptionState,
+    api_key: &str,
+    vocabulary_term_list: Option<&[String]>,
+    model: &str,
+    language: Option<&str>,
+    url: &str,
+    use_bearer: bool,
+    include_model: bool,
+) -> Result<(String, f64), AttemptFailure> {
+    let no_retry = |error: TranscriptionError| AttemptFailure {
+        error,
+        kind: FailureKind::NoRetry,
+    };
+
+    // Build multipart form
+    let file_part = reqwest::multipart::Part::bytes(wav_data)
+        .file_name("recording.wav")
+        .mime_str("audio/wav")
+        .map_err(|e| no_retry(TranscriptionError::RequestFailed(e.to_string())))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", file_part)
+        .text("response_format", "verbose_json");
+
+    // Azure deployment-path 不需要 model 欄位（部署已在 URL）
+    if include_model {
+        form = form.text("model", model.to_string());
+    }
+
+    // Conditionally add language — None means auto-detect
+    if let Some(lang) = language {
+        form = form.text("language", lang.to_string());
+    }
+
+    if let Some(terms) = vocabulary_term_list {
+        if !terms.is_empty() {
+            let prompt = format_whisper_prompt(terms);
+            form = form.text("prompt", prompt);
+        }
+    }
+
+    // Send request (reuse shared client for connection pooling)
+    let mut request_builder = transcription_state.client.post(url);
+    request_builder = if use_bearer {
+        request_builder.bearer_auth(api_key)
+    } else {
+        request_builder.header("api-key", api_key)
+    };
+    let response = match request_builder.multipart(form).send().await {
+        Ok(response) => response,
+        Err(e) => {
+            // timeout 不重試：120 秒才超時的請求再試兩次是災難；只有連線建立失敗才重試
+            let kind = if e.is_connect() {
+                FailureKind::Connect
+            } else {
+                FailureKind::NoRetry
+            };
+            return Err(AttemptFailure {
+                error: TranscriptionError::RequestFailed(e.to_string()),
+                kind,
+            });
+        }
+    };
+
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        let retry_after_secs = parse_retry_after_secs(
+            response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok()),
+        );
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Failed to read error body".to_string());
+        let kind = match status {
+            429 => FailureKind::RateLimited { retry_after_secs },
+            // 5xx 刻意不採用 Retry-After，固定短 backoff 即可
+            500..=599 => FailureKind::ServerError,
+            _ => FailureKind::NoRetry,
+        };
+        return Err(AttemptFailure {
+            error: TranscriptionError::ApiError(status, body),
+            kind,
+        });
+    }
+
+    // Parse response
+    let json: WhisperVerboseResponse = response
+        .json()
+        .await
+        .map_err(|e| no_retry(TranscriptionError::ParseError(e.to_string())))?;
+
+    let raw_text = json.text.trim().to_string();
+    // Use MIN: if any segment detects speech (low NSP), trust it — real speech
+    // always produces at least one low-NSP segment, while pure noise/hallucination
+    // keeps all segments high.
+    let no_speech_probability = json
+        .segments
+        .iter()
+        .map(|s| s.no_speech_prob)
+        .fold(1.0_f64, f64::min);
+    // If no segments, treat as full silence
+    let no_speech_probability = if json.segments.is_empty() {
+        1.0
+    } else {
+        no_speech_probability
+    };
+
+    Ok((raw_text, no_speech_probability))
+}
+
 async fn send_transcription_request(
     wav_data: Vec<u8>,
     transcription_state: &TranscriptionState,
@@ -170,22 +368,7 @@ async fn send_transcription_request(
     }
 
     let model = model_id.unwrap_or_else(|| DEFAULT_WHISPER_MODEL_ID.to_string());
-
-    // 依 provider 決定 URL、是否帶 model 欄位、與認證 header 型式
-    let (url, use_bearer, include_model) = match &azure {
-        Some(cfg) => {
-            let base = cfg.endpoint.trim_end_matches('/');
-            (
-                format!(
-                    "{}/openai/deployments/{}/audio/transcriptions?api-version={}",
-                    base, cfg.deployment, cfg.api_version
-                ),
-                cfg.use_bearer,
-                false,
-            )
-        }
-        None => (GROQ_API_URL.to_string(), true, true),
-    };
+    let (url, use_bearer, include_model) = resolve_transcription_endpoint(&azure);
 
     log::info!(
         "[transcription] Sending {} bytes WAV to {} (model={})",
@@ -194,93 +377,68 @@ async fn send_transcription_request(
         model
     );
 
+    // 計時涵蓋重試等待——維持「使用者感受時長」語意
     let start_time = Instant::now();
+    let mut wav_data = Some(wav_data);
 
-    // Build multipart form
-    let file_part = reqwest::multipart::Part::bytes(wav_data)
-        .file_name("recording.wav")
-        .mime_str("audio/wav")
-        .map_err(|e| TranscriptionError::RequestFailed(e.to_string()))?;
+    for attempt in 1..=MAX_TRANSCRIPTION_ATTEMPTS {
+        // 最後一次嘗試 move 原始資料，clone 只發生在還有重試機會時
+        let data = if attempt < MAX_TRANSCRIPTION_ATTEMPTS {
+            wav_data.as_ref().expect("wav_data taken early").clone()
+        } else {
+            wav_data.take().expect("wav_data taken early")
+        };
 
-    let mut form = reqwest::multipart::Form::new()
-        .part("file", file_part)
-        .text("response_format", "verbose_json");
-
-    // Azure deployment-path 不需要 model 欄位（部署已在 URL）
-    if include_model {
-        form = form.text("model", model);
-    }
-
-    // Conditionally add language — None means auto-detect
-    if let Some(lang) = language {
-        form = form.text("language", lang);
-    }
-
-    if let Some(ref terms) = vocabulary_term_list {
-        if !terms.is_empty() {
-            let prompt = format_whisper_prompt(terms);
-            form = form.text("prompt", prompt);
+        match attempt_transcription_request(
+            data,
+            transcription_state,
+            &api_key,
+            vocabulary_term_list.as_deref(),
+            &model,
+            language.as_deref(),
+            &url,
+            use_bearer,
+            include_model,
+        )
+        .await
+        {
+            Ok((raw_text, no_speech_probability)) => {
+                let transcription_duration_ms = start_time.elapsed().as_secs_f64() * 1000.0;
+                log::info!(
+                    "[transcription] Response in {transcription_duration_ms:.0}ms (attempt {attempt}): \"{raw_text}\" (noSpeechProb={no_speech_probability:.3})"
+                );
+                return Ok(TranscriptionResult {
+                    raw_text,
+                    transcription_duration_ms,
+                    no_speech_probability,
+                    // Live path doesn't compute energy here; retranscribe_from_file fills these in.
+                    peak_energy_level: 0.0,
+                    rms_energy_level: 0.0,
+                });
+            }
+            Err(failure) => {
+                if attempt < MAX_TRANSCRIPTION_ATTEMPTS {
+                    if let Some(wait) = retry_wait_secs(&failure.kind, attempt) {
+                        log::warn!(
+                            "[transcription] Attempt {attempt} failed ({}): {}; retrying in {wait}s",
+                            failure_kind_label(&failure.kind),
+                            failure.error
+                        );
+                        tokio::time::sleep(Duration::from_secs(wait)).await;
+                        continue;
+                    }
+                }
+                log::warn!(
+                    "[transcription] Attempt {attempt} failed ({}), giving up: {}",
+                    failure_kind_label(&failure.kind),
+                    failure.error
+                );
+                return Err(failure.error);
+            }
         }
     }
 
-    // Send request (reuse shared client for connection pooling)
-    let mut request_builder = transcription_state.client.post(&url);
-    request_builder = if use_bearer {
-        request_builder.bearer_auth(&api_key)
-    } else {
-        request_builder.header("api-key", &api_key)
-    };
-    let response = request_builder
-        .multipart(form)
-        .send()
-        .await
-        .map_err(|e| TranscriptionError::RequestFailed(e.to_string()))?;
-
-    if !response.status().is_success() {
-        let status = response.status().as_u16();
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Failed to read error body".to_string());
-        return Err(TranscriptionError::ApiError(status, body));
-    }
-
-    // Parse response
-    let json: WhisperVerboseResponse = response
-        .json()
-        .await
-        .map_err(|e| TranscriptionError::ParseError(e.to_string()))?;
-
-    let raw_text = json.text.trim().to_string();
-    // Use MIN: if any segment detects speech (low NSP), trust it — real speech
-    // always produces at least one low-NSP segment, while pure noise/hallucination
-    // keeps all segments high.
-    let no_speech_probability = json
-        .segments
-        .iter()
-        .map(|s| s.no_speech_prob)
-        .fold(1.0_f64, f64::min);
-    // If no segments, treat as full silence
-    let no_speech_probability = if json.segments.is_empty() {
-        1.0
-    } else {
-        no_speech_probability
-    };
-
-    let transcription_duration_ms = start_time.elapsed().as_secs_f64() * 1000.0;
-
-    log::info!(
-        "[transcription] Response in {transcription_duration_ms:.0}ms: \"{raw_text}\" (noSpeechProb={no_speech_probability:.3})"
-    );
-
-    Ok(TranscriptionResult {
-        raw_text,
-        transcription_duration_ms,
-        no_speech_probability,
-        // Live path doesn't compute energy here; retranscribe_from_file fills these in.
-        peak_energy_level: 0.0,
-        rms_energy_level: 0.0,
-    })
+    unreachable!("retry loop always returns within MAX_TRANSCRIPTION_ATTEMPTS")
 }
 
 /// Locate the byte offset of the PCM samples (start of the "data" sub-chunk body)
@@ -447,22 +605,29 @@ pub async fn test_whisper_connection(
 
     let azure = build_azure_whisper_config(provider, endpoint, deployment, api_version, auth_mode)?;
 
+    let model = model_id.unwrap_or_else(|| DEFAULT_WHISPER_MODEL_ID.to_string());
+    let (url, use_bearer, include_model) = resolve_transcription_endpoint(&azure);
+
     // 1 秒 16kHz silence ≈ 32044 bytes，遠超過 MINIMUM_AUDIO_SIZE 的 1000 byte 下限。
     let silence_samples = vec![0i16; 16_000];
     let wav_data = super::audio_recorder::encode_wav(&silence_samples, 16_000)
         .map_err(|e| TranscriptionError::RequestFailed(e.to_string()))?;
 
-    send_transcription_request(
+    // 連線測試走單次嘗試——要的就是即時真實結果，不重試
+    attempt_transcription_request(
         wav_data,
         &transcription_state,
-        api_key,
+        &api_key,
         None,
-        model_id,
+        &model,
         None,
-        azure,
+        &url,
+        use_bearer,
+        include_model,
     )
     .await
     .map(|_| ())
+    .map_err(|failure| failure.error)
 }
 
 // ========== Tests ==========
@@ -470,6 +635,85 @@ pub async fn test_whisper_connection(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ========== Retry classification (gh-10) ==========
+
+    #[test]
+    fn test_parse_retry_after_secs() {
+        assert_eq!(parse_retry_after_secs(Some("3")), Some(3));
+        assert_eq!(parse_retry_after_secs(Some(" 5 ")), Some(5));
+        assert_eq!(parse_retry_after_secs(Some("0")), Some(0));
+        // HTTP-date 格式不支援 → 退回固定 backoff
+        assert_eq!(
+            parse_retry_after_secs(Some("Wed, 21 Oct 2026 07:28:00 GMT")),
+            None
+        );
+        assert_eq!(parse_retry_after_secs(None), None);
+    }
+
+    #[test]
+    fn test_retry_wait_rate_limited_honors_retry_after() {
+        let kind = FailureKind::RateLimited {
+            retry_after_secs: Some(3),
+        };
+        assert_eq!(retry_wait_secs(&kind, 1), Some(3));
+    }
+
+    #[test]
+    fn test_retry_wait_rate_limited_over_cap_gives_up() {
+        let kind = FailureKind::RateLimited {
+            retry_after_secs: Some(MAX_RETRY_AFTER_WAIT_SECS + 1),
+        };
+        assert_eq!(retry_wait_secs(&kind, 1), None);
+    }
+
+    #[test]
+    fn test_retry_wait_rate_limited_without_hint_uses_backoff() {
+        let kind = FailureKind::RateLimited {
+            retry_after_secs: None,
+        };
+        assert_eq!(retry_wait_secs(&kind, 1), Some(RETRY_BACKOFF_SECS[0]));
+        assert_eq!(retry_wait_secs(&kind, 2), Some(RETRY_BACKOFF_SECS[1]));
+    }
+
+    #[test]
+    fn test_retry_wait_server_error_and_connect_use_backoff() {
+        assert_eq!(
+            retry_wait_secs(&FailureKind::ServerError, 1),
+            Some(RETRY_BACKOFF_SECS[0])
+        );
+        assert_eq!(
+            retry_wait_secs(&FailureKind::Connect, 2),
+            Some(RETRY_BACKOFF_SECS[1])
+        );
+    }
+
+    #[test]
+    fn test_retry_wait_no_retry_returns_none() {
+        assert_eq!(retry_wait_secs(&FailureKind::NoRetry, 1), None);
+    }
+
+    #[test]
+    fn test_retry_wait_backoff_index_saturates() {
+        // attempt 序號超過 backoff 陣列長度時，沿用最後一段 backoff（不 panic）
+        assert_eq!(
+            retry_wait_secs(&FailureKind::ServerError, 9),
+            Some(RETRY_BACKOFF_SECS[RETRY_BACKOFF_SECS.len() - 1])
+        );
+    }
+
+    #[test]
+    fn test_failure_kind_label() {
+        assert_eq!(
+            failure_kind_label(&FailureKind::RateLimited {
+                retry_after_secs: None
+            }),
+            "rate-limited"
+        );
+        assert_eq!(failure_kind_label(&FailureKind::ServerError), "server-error");
+        assert_eq!(failure_kind_label(&FailureKind::Connect), "connect-failed");
+        assert_eq!(failure_kind_label(&FailureKind::NoRetry), "no-retry");
+    }
 
     #[test]
     fn test_format_whisper_prompt_basic() {

--- a/src-tauri/src/plugins/transcription.rs
+++ b/src-tauri/src/plugins/transcription.rs
@@ -210,6 +210,16 @@ fn retry_wait_secs(kind: &FailureKind, attempt: u32) -> Option<u64> {
     }
 }
 
+/// 依 HTTP 狀態碼分類是否可重試。429 帶 Retry-After；408/5xx 為暫時性；其餘（含其他 4xx）不重試。
+fn classify_response_status(status: u16, retry_after_secs: Option<u64>) -> FailureKind {
+    match status {
+        429 => FailureKind::RateLimited { retry_after_secs },
+        // 408 Request Timeout 與 5xx 皆屬暫時性 → 固定短 backoff（不採用 Retry-After）
+        408 | 500..=599 => FailureKind::ServerError,
+        _ => FailureKind::NoRetry,
+    }
+}
+
 // ========== Shared Transcription Logic ==========
 
 /// 依 provider 決定 URL、是否帶 model 欄位、與認證 header 型式。跨重試不變、解析一次即可。
@@ -286,8 +296,11 @@ async fn attempt_transcription_request(
     let response = match request_builder.multipart(form).send().await {
         Ok(response) => response,
         Err(e) => {
-            // timeout 不重試：120 秒才超時的請求再試兩次是災難；只有連線建立失敗才重試
-            let kind = if e.is_connect() {
+            // timeout 不重試：120 秒才超時的請求再試兩次是災難。先判 timeout（is_timeout 與
+            // is_connect 未保證互斥），再判連線建立失敗才重試。
+            let kind = if e.is_timeout() {
+                FailureKind::NoRetry
+            } else if e.is_connect() {
                 FailureKind::Connect
             } else {
                 FailureKind::NoRetry
@@ -311,12 +324,7 @@ async fn attempt_transcription_request(
             .text()
             .await
             .unwrap_or_else(|_| "Failed to read error body".to_string());
-        let kind = match status {
-            429 => FailureKind::RateLimited { retry_after_secs },
-            // 5xx 刻意不採用 Retry-After，固定短 backoff 即可
-            500..=599 => FailureKind::ServerError,
-            _ => FailureKind::NoRetry,
-        };
+        let kind = classify_response_status(status, retry_after_secs);
         return Err(AttemptFailure {
             error: TranscriptionError::ApiError(status, body),
             kind,
@@ -713,6 +721,38 @@ mod tests {
         assert_eq!(failure_kind_label(&FailureKind::ServerError), "server-error");
         assert_eq!(failure_kind_label(&FailureKind::Connect), "connect-failed");
         assert_eq!(failure_kind_label(&FailureKind::NoRetry), "no-retry");
+    }
+
+    #[test]
+    fn test_classify_response_status() {
+        assert!(matches!(
+            classify_response_status(429, Some(3)),
+            FailureKind::RateLimited {
+                retry_after_secs: Some(3)
+            }
+        ));
+        // 408 與 5xx 皆可重試
+        assert!(matches!(
+            classify_response_status(408, None),
+            FailureKind::ServerError
+        ));
+        assert!(matches!(
+            classify_response_status(500, None),
+            FailureKind::ServerError
+        ));
+        assert!(matches!(
+            classify_response_status(503, None),
+            FailureKind::ServerError
+        ));
+        // 其他 4xx 不重試
+        assert!(matches!(
+            classify_response_status(400, None),
+            FailureKind::NoRetry
+        ));
+        assert!(matches!(
+            classify_response_status(404, None),
+            FailureKind::NoRetry
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Backport **A3** from upstream #10. Transient Groq/Azure failures (429 rate limits, 5xx, dropped connections) previously surfaced as a hard failure with **no retry**.

## What
- Up to **3 attempts**: 429 honors `Retry-After` (>10s cap → give up), 5xx/connect use 1s/2s backoff; **timeout and 4xx/parse are not retried**; timing includes retry waits (user-perceived duration).
- The WAV buffer is **cloned only while a retry is still possible** (final attempt moves it) — successful requests pay no needless copy.
- Retry applies to **both Groq and Azure** (endpoint/auth resolved once via `resolve_transcription_endpoint`, passed into each attempt).
- `test_whisper_connection` uses a **single attempt** (a connectivity test wants an immediate real result, not a retry).
- Split into pure classification (`parse_retry_after_secs`/`retry_wait_secs`/`failure_kind_label`) + `attempt_transcription_request` + retry loop. Added `tokio` (`time`) as a direct dep.

No IPC change (command signatures + `TranscriptionResult` unchanged).

## Validation
`cargo check` ✅ · `cargo test --lib` → **97 passed** (incl. 8 new retry tests) ✅ · `cargo clippy --all-targets -D warnings` ✅.

Refs upstream chenjackle45/SayIt#10
