### PR TITLE
feat(edit-mode): AX selection detection replaces Cmd+C simulation (#69)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -503,6 +503,7 @@ pub fn run() {
             plugins::keyboard_monitor::start_correction_monitor,
             plugins::text_field_reader::read_focused_text_field,
             plugins::text_field_reader::read_selected_text,
+            plugins::text_field_reader::read_selection_state,
             plugins::audio_recorder::get_default_input_device_name,
             plugins::audio_recorder::list_audio_input_devices,
             plugins::audio_recorder::start_audio_preview,

--- a/src-tauri/src/plugins/text_field_reader.rs
+++ b/src-tauri/src/plugins/text_field_reader.rs
@@ -21,12 +21,67 @@ pub fn read_focused_text_field() -> Result<Option<String>, String> {
     }
 }
 
-/// 讀取當前聚焦文字欄位中被選取（highlight）的文字。
-/// 用於編輯模式偵測：有選取文字時進入編輯模式，語音變成指令。
-/// 透過模擬 Cmd+C / Ctrl+C 擷取剪貼簿內容，不依賴 Accessibility API。
+/// 編輯模式的「剪貼簿後備」路徑：僅在 `read_selection_state` 回報
+/// unavailable（AX 不可見的 App）時、於錄音停止且按鍵放開後由前端呼叫。
+/// 透過模擬 Cmd+C / Ctrl+C 擷取剪貼簿內容。
 #[tauri::command]
 pub fn read_selected_text() -> Result<Option<String>, String> {
     super::clipboard_paste::capture_selected_text_via_clipboard()
+}
+
+/// 選取狀態偵測結果（#24/#25 編輯模式判定）。
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectionState {
+    /// "selection" | "noSelection" | "unavailable"
+    pub kind: String,
+    pub text: Option<String>,
+}
+
+impl SelectionState {
+    // selection / no_selection 僅 macOS 的 AX 分類器使用；
+    // Windows 端一律 unavailable，cfg 閘避免 dead_code 撞上 clippy -D warnings
+    #[cfg(target_os = "macos")]
+    fn selection(text: String) -> Self {
+        Self {
+            kind: "selection".to_string(),
+            text: Some(text),
+        }
+    }
+    #[cfg(target_os = "macos")]
+    fn no_selection() -> Self {
+        Self {
+            kind: "noSelection".to_string(),
+            text: None,
+        }
+    }
+    fn unavailable() -> Self {
+        Self {
+            kind: "unavailable".to_string(),
+            text: None,
+        }
+    }
+}
+
+/// 讀取聚焦文字欄位的選取狀態——編輯模式判定的主路徑。
+/// macOS：AX 被動查詢（零按鍵模擬，#25 的字元污染在此路徑不可能發生）。三態：
+///   selection    — 確定有選取，text 為選取內容 → 前端直接進編輯模式
+///   noSelection  — 確定無選取（AX 可讀且長度 0）→ 一般聽寫，
+///                  CodeMirror 類編輯器的「無選取複製整行」誤判（#24）在此被排除
+///   unavailable  — AX 不可見或讀值失真（Heptabase/LINE 類）→ 前端在錄音停止、
+///                  按鍵放開後改走剪貼簿後備（read_selected_text）
+/// Windows / 其他平台：一律 unavailable（沿用剪貼簿後備；選取讀取待 UIA 版補上）。
+#[tauri::command]
+pub fn read_selection_state() -> SelectionState {
+    #[cfg(target_os = "macos")]
+    {
+        macos::read_selection_state_impl()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        SelectionState::unavailable()
+    }
 }
 
 // ========== macOS: AXUIElement ==========
@@ -48,10 +103,18 @@ mod macos {
     const K_AX_FOCUSED_UI_ELEMENT_ATTRIBUTE: &str = "AXFocusedUIElement";
     const K_AX_VALUE_ATTRIBUTE: &str = "AXValue";
     const K_AX_SELECTED_TEXT_RANGE_ATTRIBUTE: &str = "AXSelectedTextRange";
+    const K_AX_SELECTED_TEXT_ATTRIBUTE: &str = "AXSelectedText";
     const K_AX_ROLE_ATTRIBUTE: &str = "AXRole";
 
     const CONTEXT_CHARS: usize = 50;
     const FALLBACK_CHARS: usize = 100;
+
+    /// 選取狀態讀取的總 timeout：AX 是同步跨進程呼叫，目標 App 卡死會阻塞
+    /// （對齊 windows_impl 的守衛設計）。上限涵蓋「解析失敗 → 戳醒 Electron →
+    /// 等樹重建 → 重試」的最長路徑。
+    const SELECTION_READ_TIMEOUT_MS: u64 = 600;
+    /// 對 Electron 施加 AXManualAccessibility 後等樹重建的時間。
+    const POKE_SETTLE_MS: u64 = 150;
 
     extern "C" {
         fn AXUIElementCreateSystemWide() -> AXUIElementRef;
@@ -59,6 +122,11 @@ mod macos {
             element: AXUIElementRef,
             attribute: CFTypeRef,
             value: *mut CFTypeRef,
+        ) -> AXError;
+        fn AXUIElementSetAttributeValue(
+            element: AXUIElementRef,
+            attribute: CFTypeRef,
+            value: CFTypeRef,
         ) -> AXError;
     }
 
@@ -97,7 +165,8 @@ mod macos {
         Some(cf_string.to_string())
     }
 
-    fn get_cursor_position(element: AXUIElementRef) -> Option<usize> {
+    /// 讀取 AXSelectedTextRange 並解出 CFRange（游標位置 + 選取長度的共用來源）。
+    fn read_selected_text_range(element: AXUIElementRef) -> Option<CFRange> {
         let value = get_ax_attribute(element, K_AX_SELECTED_TEXT_RANGE_ATTRIBUTE)?;
 
         let mut range = CFRange {
@@ -115,7 +184,16 @@ mod macos {
 
         unsafe { CFRelease(value) };
 
-        if success && range.location >= 0 {
+        if success {
+            Some(range)
+        } else {
+            None
+        }
+    }
+
+    fn get_cursor_position(element: AXUIElementRef) -> Option<usize> {
+        let range = read_selected_text_range(element)?;
+        if range.location >= 0 {
             Some(range.location as usize)
         } else {
             None
@@ -250,6 +328,136 @@ mod macos {
                 }
             }
             _ => Ok(None),
+        }
+    }
+
+    // ========== 選取狀態偵測（#24/#25 編輯模式判定） ==========
+
+    use super::SelectionState;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Duration;
+
+    type SelectionRespTx = SyncSender<SelectionState>;
+
+    static SELECTION_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+    static SELECTION_WORKER: OnceLock<Option<Mutex<SyncSender<SelectionRespTx>>>> = OnceLock::new();
+
+    /// 讀取聚焦元素的選取長度（AXSelectedTextRange.length）。
+    /// length > 0 = 真的有選取；length == 0 = 只有游標、沒選取
+    /// （編輯器「無選取時 Cmd+C 複製整行」不影響 AX 層的選取範圍，故能分辨）。
+    fn get_selection_length(element: AXUIElementRef) -> Option<i64> {
+        read_selected_text_range(element).map(|range| range.length)
+    }
+
+    /// Electron/Chromium 的無障礙樹是惰性啟用的：對焦點 App 設
+    /// AXManualAccessibility=true 可強制喚醒完整樹（Electron 官方支援的旗標）。
+    /// 對原生 App 設此屬性會失敗，無副作用。
+    fn poke_focused_app_manual_accessibility() {
+        let system_wide = unsafe { AXUIElementCreateSystemWide() };
+        if system_wide.is_null() {
+            return;
+        }
+        if let Some(app) = get_ax_attribute(system_wide, K_AX_FOCUSED_APPLICATION_ATTRIBUTE) {
+            let attr = CFString::new("AXManualAccessibility");
+            let value = core_foundation::boolean::CFBoolean::true_value();
+            unsafe {
+                AXUIElementSetAttributeValue(app, attr.as_CFTypeRef(), value.as_CFTypeRef());
+                CFRelease(app);
+            }
+        }
+        unsafe { CFRelease(system_wide) };
+    }
+
+    /// 依已解析的聚焦文字元素分類選取狀態。消耗 ctx 並負責釋放。
+    fn classify_selection(ctx: FocusedElementContext) -> SelectionState {
+        let state = match get_selection_length(ctx.target_element) {
+            Some(len) if len > 0 => {
+                match get_ax_string_attribute(ctx.target_element, K_AX_SELECTED_TEXT_ATTRIBUTE) {
+                    Some(text) if !text.trim().is_empty() => SelectionState::selection(text),
+                    // 長度 > 0 但文字讀不到/為空 = 橋接失真（Electron 已知失效模式），
+                    // 交給剪貼簿後備嘗試撈回真實選取
+                    _ => SelectionState::unavailable(),
+                }
+            }
+            Some(_) => SelectionState::no_selection(),
+            // 元素是文字輸入類但範圍屬性不支援 → 無法判定
+            None => SelectionState::unavailable(),
+        };
+        ctx.cleanup();
+        state
+    }
+
+    /// 阻塞式選取偵測：第一次解析失敗時戳醒 Electron 樹再試一次。
+    /// 全程只做被動 AX 查詢，不模擬任何按鍵。
+    fn selection_probe_blocking() -> SelectionState {
+        if let Some(ctx) = resolve_focused_text_element() {
+            return classify_selection(ctx);
+        }
+        poke_focused_app_manual_accessibility();
+        std::thread::sleep(Duration::from_millis(POKE_SETTLE_MS));
+        match resolve_focused_text_element() {
+            Some(ctx) => classify_selection(ctx),
+            None => SelectionState::unavailable(),
+        }
+    }
+
+    /// 入口：AX 讀取跑在單一常駐 worker 執行緒上、最多等 SELECTION_READ_TIMEOUT_MS
+    /// （AX 為同步跨進程呼叫，目標 App 卡死不可拖住 command thread——
+    /// 對齊 windows_impl 的守衛模式；常駐而非每次 spawn，卡死時最多損失
+    /// 一條執行緒、不會隨熱鍵次數無上界累積）。逾時 / 忙碌一律回 unavailable，
+    /// 由前端剪貼簿後備接手。
+    pub fn read_selection_state_impl() -> SelectionState {
+        let sender = match selection_worker_sender() {
+            Some(s) => s,
+            None => return SelectionState::unavailable(),
+        };
+
+        // single-flight：熱鍵連按時避免 AX 讀取堆疊。
+        // 旗標由「呼叫端」在所有路徑後無條件清掉，不依賴 worker
+        // （worker 卡死時遲到結果只會送進已 drop 的 receiver 而被丟棄）
+        if SELECTION_IN_FLIGHT.swap(true, Ordering::AcqRel) {
+            return SelectionState::unavailable();
+        }
+
+        let outcome = selection_read_once(&sender);
+        SELECTION_IN_FLIGHT.store(false, Ordering::Release);
+        outcome
+    }
+
+    fn selection_read_once(sender: &SyncSender<SelectionRespTx>) -> SelectionState {
+        let (resp_tx, resp_rx) = sync_channel::<SelectionState>(1);
+        if sender.try_send(resp_tx).is_err() {
+            // worker 還卡在上一個請求（目標 App 的 AX server 無回應）
+            return SelectionState::unavailable();
+        }
+        resp_rx
+            .recv_timeout(Duration::from_millis(SELECTION_READ_TIMEOUT_MS))
+            .unwrap_or_else(|_| SelectionState::unavailable())
+    }
+
+    fn selection_worker_sender() -> Option<SyncSender<SelectionRespTx>> {
+        let cell = SELECTION_WORKER.get_or_init(spawn_selection_worker);
+        let mutex = cell.as_ref()?;
+        let guard = mutex.lock().ok()?;
+        Some(guard.clone())
+    }
+
+    fn spawn_selection_worker() -> Option<Mutex<SyncSender<SelectionRespTx>>> {
+        let (req_tx, req_rx) = sync_channel::<SelectionRespTx>(1);
+        std::thread::Builder::new()
+            .name("ax-selection-reader".into())
+            .spawn(move || selection_worker_loop(req_rx))
+            .ok()?;
+        Some(Mutex::new(req_tx))
+    }
+
+    fn selection_worker_loop(req_rx: Receiver<SelectionRespTx>) {
+        while let Ok(resp_tx) = req_rx.recv() {
+            let result = selection_probe_blocking();
+            // 呼叫端可能已逾時離開（receiver drop）：try_send 失敗直接丟棄
+            let _ = resp_tx.try_send(result);
         }
     }
 

--- a/src/stores/useVoiceFlowStore.ts
+++ b/src/stores/useVoiceFlowStore.ts
@@ -114,6 +114,20 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
   let abortController: AbortController | null = null;
   const editSourceText = ref<string | null>(null);
   const isEditMode = computed<boolean>(() => editSourceText.value !== null);
+  // AX 不可見 App（read_selection_state 回 unavailable）的剪貼簿後備旗標：
+  // 錄音停止、按鍵放開後才執行 read_selected_text
+  let pendingClipboardSelectionCheck = false;
+  let pendingSelectionCapture: Promise<void> | null = null;
+  // 錄音世代編號：AX 判定（最長 600ms）與剪貼簿後備（250ms 計時器）都是
+  // 非同步回呼，可能在「下一輪錄音已開始」後才落地——寫入前必須比對世代，
+  // 過期回呼直接失效（含 ESC 取消 / 雙擊切換後立刻重錄的情境）
+  let recordingEpoch = 0;
+  // 本世代的 AX 判定是否已有結論：停止錄音時若 AX 還沒回覆，
+  // 保守走剪貼簿後備（等同舊行為），避免慢速 AX 讓編輯模式靜默消失
+  let selectionProbeSettledEpoch = -1;
+  // 等按鍵完全放開的緩衝：toggle 模式的「停止」由第二次按下觸發，
+  // 該瞬間按鍵仍壓著，立刻模擬 Cmd+C 會重演 #25 的字元污染
+  const CLIPBOARD_FALLBACK_KEY_RELEASE_DELAY_MS = 250;
   const isRetryAttempt = ref<boolean>(false);
   const canRetry = computed<boolean>(
     () =>
@@ -905,6 +919,10 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
 
   function applyDoubleTapModeSwitch() {
     isRecording.value = false;
+    // 世代 +1：這輪錄音被雙擊靜默取消，途中的選取偵測回呼全部失效
+    recordingEpoch += 1;
+    pendingClipboardSelectionCheck = false;
+    pendingSelectionCapture = null;
 
     // Toggle prompt mode: minimal ↔ active
     const settingsStore = useSettingsStore();
@@ -984,6 +1002,10 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
     stopCorrectionSnapshotPolling();
     cleanupCorrectionMonitorListener();
     void restoreSystemAudio();
+    // 世代 +1：讓仍在途的 AX 判定 / 剪貼簿後備回呼全部過期失效
+    recordingEpoch += 1;
+    pendingClipboardSelectionCheck = false;
+    pendingSelectionCapture = null;
 
     // 重置 toggle 模式狀態
     void invoke("reset_hotkey_state").catch(() => {});
@@ -1010,15 +1032,32 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
     // 捕獲當前前景視窗（Windows: HUD show 前記住目標，貼上前恢復焦點）
     void invoke("capture_target_window").catch(() => {});
 
-    // 偵測選取文字（非阻塞）：模擬 Cmd+C 讀剪貼簿，~100ms，遠在錄音結束前完成
+    // 偵測選取文字（非阻塞）：AX 被動查詢，零按鍵模擬（#24/#25）。
+    // AX 不可見的 App 標記剪貼簿後備，延後到錄音停止、按鍵放開後執行
     editSourceText.value = null;
-    invoke<string | null>("read_selected_text")
-      .then((selectedText) => {
-        if (selectedText && selectedText.trim().length > 0) {
-          editSourceText.value = selectedText;
+    pendingClipboardSelectionCheck = false;
+    pendingSelectionCapture = null;
+    recordingEpoch += 1;
+    const probeEpoch = recordingEpoch;
+    invoke<{ kind: string; text: string | null }>("read_selection_state")
+      .then((state) => {
+        // 過期回呼（下一輪錄音已開始）直接失效，防止跨錄音狀態污染
+        if (probeEpoch !== recordingEpoch || !state) return;
+        selectionProbeSettledEpoch = probeEpoch;
+        if (
+          state.kind === "selection" &&
+          state.text &&
+          state.text.trim().length > 0
+        ) {
+          editSourceText.value = state.text;
           writeInfoLog(
-            `useVoiceFlowStore: edit mode activated, selectedText length=${selectedText.length}`,
+            `useVoiceFlowStore: edit mode activated (ax), selectedText length=${state.text.length}`,
           );
+        } else if (state.kind === "noSelection") {
+          // AX 的明確否定是權威答案：若慢速後備已誤寫（整行複製），以此為準清掉
+          editSourceText.value = null;
+        } else if (state.kind === "unavailable") {
+          pendingClipboardSelectionCheck = true;
         }
       })
       .catch(() => {});
@@ -1074,6 +1113,42 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
     await restoreSystemAudio();
     playSoundIfEnabled("play_stop_sound");
     stopElapsedTimer();
+
+    // AX 不可見 App 的剪貼簿後備：延遲等按鍵完全放開後才模擬 Cmd+C。
+    // 包成 Promise：轉錄若比後備先完成，編輯模式判定前要能 await 它。
+    // AX 到停止時還沒回覆（慢速 App）也保守走後備——等同舊行為，
+    // 避免編輯模式在這種時序下靜默消失
+    if (
+      pendingClipboardSelectionCheck ||
+      selectionProbeSettledEpoch !== recordingEpoch
+    ) {
+      pendingClipboardSelectionCheck = false;
+      const fallbackEpoch = recordingEpoch;
+      pendingSelectionCapture = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          if (fallbackEpoch !== recordingEpoch) {
+            resolve();
+            return;
+          }
+          invoke<string | null>("read_selected_text")
+            .then((selectedText) => {
+              if (fallbackEpoch !== recordingEpoch) return;
+              if (
+                selectedText &&
+                selectedText.trim().length > 0 &&
+                !editSourceText.value
+              ) {
+                editSourceText.value = selectedText;
+                writeInfoLog(
+                  `useVoiceFlowStore: edit mode activated (clipboard fallback), selectedText length=${selectedText.length}`,
+                );
+              }
+            })
+            .catch(() => {})
+            .finally(resolve);
+        }, CLIPBOARD_FALLBACK_KEY_RELEASE_DELAY_MS);
+      });
+    }
 
     // 生成 transcriptionId 貫穿整個流程
     const transcriptionId = crypto.randomUUID();
@@ -1267,6 +1342,12 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
           `useVoiceFlowStore: hallucination intercepted (reason=${hallucinationDetectionResult.reason})`,
         );
         return;
+      }
+
+      // 剪貼簿後備可能還在等按鍵放開（轉錄比後備快時）：判定模式前先等它完成
+      if (pendingSelectionCapture) {
+        await pendingSelectionCapture;
+        pendingSelectionCapture = null;
       }
 
       // 編輯模式：語音是指令，選取文字是待處理內容

--- a/tests/unit/use-voice-flow-store.test.ts
+++ b/tests/unit/use-voice-flow-store.test.ts
@@ -142,6 +142,7 @@ vi.mock("../../src/lib/enhancer", () => {
   }
   return {
     enhanceText: mockEnhanceText,
+    buildSystemPrompt: (basePrompt: string) => basePrompt,
     EnhancerApiError,
   };
 });
@@ -471,6 +472,86 @@ describe("useVoiceFlowStore", () => {
     expect(mockEmit).toHaveBeenCalledWith("voice-flow:state-changed", {
       status: "success",
       message: "voiceFlow.pasteSuccess",
+    });
+  });
+
+  describe("選取偵測三態（#24/#25 編輯模式判定）", () => {
+    function withSelectionState(
+      state: { kind: string; text: string | null },
+      clipboardText: string | null = null,
+    ) {
+      const base = createMockInvokeHandler();
+      mockInvoke.mockImplementation(async (cmd: string, args?: unknown) => {
+        if (cmd === "read_selection_state") return state;
+        if (cmd === "read_selected_text") return clipboardText;
+        return base(cmd, args);
+      });
+    }
+
+    it("[P0] AX 回報 selection 應直接進編輯模式、不呼叫剪貼簿擷取", async () => {
+      withSelectionState({ kind: "selection", text: "選取的文字" });
+      const store = useVoiceFlowStore();
+      await store.initialize();
+
+      triggerHotkeyEvent("hotkey:pressed");
+      await vi.waitFor(() => {
+        expect(store.isEditMode).toBe(true);
+      });
+
+      expect(mockInvoke).not.toHaveBeenCalledWith("read_selected_text");
+    });
+
+    it("[P0] AX 回報 noSelection 應走一般聽寫、全程不模擬 Cmd+C", async () => {
+      withSelectionState({ kind: "noSelection", text: null });
+      const store = useVoiceFlowStore();
+      await store.initialize();
+
+      triggerHotkeyEvent("hotkey:pressed");
+      await vi.waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("start_recording", {
+          deviceName: "",
+        });
+      });
+
+      triggerHotkeyEvent("hotkey:released");
+      await vi.waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("paste_text", {
+          text: "測試轉錄",
+          restoreClipboard: false,
+        });
+      });
+
+      expect(store.isEditMode).toBe(false);
+      expect(mockInvoke).not.toHaveBeenCalledWith("read_selected_text");
+    });
+
+    it("[P0] AX 回報 unavailable 應在停止錄音後走剪貼簿後備並進編輯模式", async () => {
+      withSelectionState({ kind: "unavailable", text: null }, "後備選取的文字");
+      const store = useVoiceFlowStore();
+      await store.initialize();
+
+      triggerHotkeyEvent("hotkey:pressed");
+      await vi.waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("start_recording", {
+          deviceName: "",
+        });
+      });
+      // 錄音開始階段不可有任何按鍵模擬（#25：按鍵還壓著）
+      expect(mockInvoke).not.toHaveBeenCalledWith("read_selected_text");
+
+      triggerHotkeyEvent("hotkey:released");
+      // 後備有 250ms 等按鍵放開的延遲；轉錄先完成時模式判定必須等它
+      await vi.waitFor(
+        () => {
+          expect(mockEnhanceText).toHaveBeenCalledWith(
+            "後備選取的文字",
+            expect.anything(),
+            expect.anything(),
+          );
+        },
+        { timeout: 3000 },
+      );
+      expect(mockInvoke).toHaveBeenCalledWith("read_selected_text");
     });
   });
 
@@ -2304,7 +2385,10 @@ describe("useVoiceFlowStore", () => {
         });
       });
 
-      expect(store.status).toBe("success");
+      // 選取偵測後備（250ms）拉長了貼上→success 的時序，改用 waitFor 斷言終態
+      await vi.waitFor(() => {
+        expect(store.status).toBe("success");
+      });
     });
 
     it("音效停用時不應呼叫 play_start_sound", async () => {


### PR DESCRIPTION
Backport **A4** from upstream #69. Edit-mode selection detection simulated **Cmd+C**, causing:
- **#25** — a stray "C" character when the hotkey was still held on the second (toggle) press.
- **#24** — editors (CodeMirror etc.) that copy the *whole line* when nothing is selected -> false edit-mode.

## What
- New **`read_selection_state`** three-state command (`selection` / `noSelection` / `unavailable`):
  - **macOS**: passive **AX** query on a single resident worker (600ms timeout, single-flight, mirroring the Windows-UIA guard). On parse failure it pokes Electron''s lazy AX tree (`AXManualAccessibility`) and retries once. **Zero keystroke simulation** -> #25 is physically impossible on this path. Selection length 0 = explicit no-selection -> #24 excluded.
  - **Windows / other**: always `unavailable` (keeps the clipboard fallback; UIA selection TBD).
- **Frontend dual-track**: AX probe at record start; AX-invisible apps (`unavailable`) defer to the clipboard fallback (`read_selected_text`) **250ms after stop** (key-release buffer). **Recording-epoch guards** invalidate stale AX/fallback callbacks across recordings (ESC / double-tap re-record). Edit-mode judgment `await`s the fallback when transcription finishes first.
- `read_selected_text` kept as the fallback only.

## Validation
- Local: `vue-tsc` OK, `eslint` OK, `vitest` **561** (incl. 3 new three-state tests + previously-missing edit-mode coverage), `cargo check` (Windows) OK.
- **macOS AX compile/clippy/tests validated via the CI `rust-check` (macos-latest) job** — `#[cfg(target_os="macos")]` can''t be compiled locally on Windows.
- ⚠️ **Runtime AX behavior** (does selection detection actually fire in real apps) still needs real-device testing — CI can''t click a UI.

Refs upstream chenjackle45/SayIt#69 (#24, #25)
