### PR TITLE
fix(edit-mode): harden AX selection detection hot-path (#69)

### DIFF
--- a/src-tauri/src/plugins/text_field_reader.rs
+++ b/src-tauri/src/plugins/text_field_reader.rs
@@ -72,10 +72,16 @@ impl SelectionState {
 ///                  按鍵放開後改走剪貼簿後備（read_selected_text）
 /// Windows / 其他平台：一律 unavailable（沿用剪貼簿後備；選取讀取待 UIA 版補上）。
 #[tauri::command]
-pub fn read_selection_state() -> SelectionState {
+pub async fn read_selection_state() -> SelectionState {
     #[cfg(target_os = "macos")]
     {
-        macos::read_selection_state_impl()
+        // AX 讀取最壞會等 SELECTION_READ_TIMEOUT_MS（目標 App 的 AX server 卡死時）。
+        // 同步 command 跑在 Tauri 主執行緒——若在此阻塞，會拖慢緊接其後派發的
+        // play_start_sound / start_recording invoke（錄音起點延遲 = 開頭語音被吃掉）。
+        // 放到 blocking 執行緒等待，主執行緒不被 AX 卡住。
+        tauri::async_runtime::spawn_blocking(macos::read_selection_state_impl)
+            .await
+            .unwrap_or_else(|_| SelectionState::unavailable())
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -344,11 +350,24 @@ mod macos {
     static SELECTION_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
     static SELECTION_WORKER: OnceLock<Option<Mutex<SyncSender<SelectionRespTx>>>> = OnceLock::new();
 
+    /// 判斷 AX 回報的 CFRange 是否可信：location / length 皆須非負。
+    /// 橋接失真時 AX 可能回哨兵值（如 location=-1、length=0；get_cursor_position
+    /// 已因此守 location>=0），此類範圍不可當作權威 noSelection。
+    fn is_valid_selection_range(location: i64, length: i64) -> bool {
+        location >= 0 && length >= 0
+    }
+
     /// 讀取聚焦元素的選取長度（AXSelectedTextRange.length）。
     /// length > 0 = 真的有選取；length == 0 = 只有游標、沒選取
     /// （編輯器「無選取時 Cmd+C 複製整行」不影響 AX 層的選取範圍，故能分辨）。
+    /// 無效/哨兵範圍回 None → 分類為 unavailable、交剪貼簿後備，
+    /// 不誤判為權威 noSelection 而跳過後備。
     fn get_selection_length(element: AXUIElementRef) -> Option<i64> {
-        read_selected_text_range(element).map(|range| range.length)
+        let range = read_selected_text_range(element)?;
+        if !is_valid_selection_range(range.location, range.length) {
+            return None;
+        }
+        Some(range.length)
     }
 
     /// Electron/Chromium 的無障礙樹是惰性啟用的：對焦點 App 設
@@ -445,7 +464,10 @@ mod macos {
     }
 
     fn spawn_selection_worker() -> Option<Mutex<SyncSender<SelectionRespTx>>> {
-        let (req_tx, req_rx) = sync_channel::<SelectionRespTx>(1);
+        // rendezvous（容量 0）：worker 還卡在上一個 AX 讀取（未回到 recv）時，
+        // 呼叫端的 try_send 直接失敗 → 立刻回 unavailable，而非把過期請求塞進
+        // 容量 1 的佇列、讓 worker 逾時後又白跑一輪 600ms。
+        let (req_tx, req_rx) = sync_channel::<SelectionRespTx>(0);
         std::thread::Builder::new()
             .name("ax-selection-reader".into())
             .spawn(move || selection_worker_loop(req_rx))
@@ -468,6 +490,17 @@ mod macos {
         #[test]
         fn test_extract_excerpt_empty() {
             assert_eq!(extract_excerpt("", None, 50), "");
+        }
+
+        #[test]
+        fn test_is_valid_selection_range() {
+            // 正常範圍：游標（0,0）與真實選取（5,3）皆可信
+            assert!(is_valid_selection_range(0, 0));
+            assert!(is_valid_selection_range(5, 3));
+            // 哨兵 / 失真範圍：任一為負皆不可信 → 交剪貼簿後備
+            assert!(!is_valid_selection_range(-1, 0));
+            assert!(!is_valid_selection_range(0, -1));
+            assert!(!is_valid_selection_range(-1, -1));
         }
 
         #[test]

--- a/src-tauri/src/plugins/text_field_reader.rs
+++ b/src-tauri/src/plugins/text_field_reader.rs
@@ -464,10 +464,13 @@ mod macos {
     }
 
     fn spawn_selection_worker() -> Option<Mutex<SyncSender<SelectionRespTx>>> {
-        // rendezvous（容量 0）：worker 還卡在上一個 AX 讀取（未回到 recv）時，
-        // 呼叫端的 try_send 直接失敗 → 立刻回 unavailable，而非把過期請求塞進
-        // 容量 1 的佇列、讓 worker 逾時後又白跑一輪 600ms。
-        let (req_tx, req_rx) = sync_channel::<SelectionRespTx>(0);
+        // 容量 1（不用 rendezvous 容量 0）：worker 採 lazy spawn，第一次呼叫時剛
+        // spawn 的執行緒還沒 park 在 recv()。若用容量 0，冷啟第一次 try_send 幾乎
+        // 必然失敗 → 首次編輯模式偵測退回 Cmd+C，正是 #24/#25 要消除的路徑。
+        // 容量 1 讓冷啟請求先進 buffer、worker 起來後再取。代價僅是 worker 卡死時
+        // 可能多緩一個過期請求、事後白跑一輪（結果因 receiver 已 drop 而丟棄）——
+        // 非阻斷、且受 SELECTION_IN_FLIGHT single-flight 上限保護。
+        let (req_tx, req_rx) = sync_channel::<SelectionRespTx>(1);
         std::thread::Builder::new()
             .name("ax-selection-reader".into())
             .spawn(move || selection_worker_loop(req_rx))

--- a/src/stores/useVoiceFlowStore.ts
+++ b/src/stores/useVoiceFlowStore.ts
@@ -125,9 +125,16 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
   // 本世代的 AX 判定是否已有結論：停止錄音時若 AX 還沒回覆，
   // 保守走剪貼簿後備（等同舊行為），避免慢速 AX 讓編輯模式靜默消失
   let selectionProbeSettledEpoch = -1;
+  // 本世代 AX 判定的結論類型（settled 時記錄）：慢速 AX 在後備排程後才落地
+  // noSelection 時，後備必須以 AX 為準、不再用「整行複製」覆寫（#24 復發防護）
+  let selectionProbeSettledKind: "selection" | "noSelection" | "unavailable" | null =
+    null;
   // 等按鍵完全放開的緩衝：toggle 模式的「停止」由第二次按下觸發，
   // 該瞬間按鍵仍壓著，立刻模擬 Cmd+C 會重演 #25 的字元污染
   const CLIPBOARD_FALLBACK_KEY_RELEASE_DELAY_MS = 250;
+  // 等待剪貼簿後備 Promise 的安全上限：防 read_selected_text 永不 settle（Rust
+  // 端卡死）時 await 卡住整條轉錄流程。後備正常在 250ms + Cmd+C 內完成。
+  const PENDING_SELECTION_CAPTURE_TIMEOUT_MS = 2000;
   const isRetryAttempt = ref<boolean>(false);
   const canRetry = computed<boolean>(
     () =>
@@ -1037,6 +1044,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
     editSourceText.value = null;
     pendingClipboardSelectionCheck = false;
     pendingSelectionCapture = null;
+    selectionProbeSettledKind = null;
     recordingEpoch += 1;
     const probeEpoch = recordingEpoch;
     invoke<{ kind: string; text: string | null }>("read_selection_state")
@@ -1049,14 +1057,17 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
           state.text &&
           state.text.trim().length > 0
         ) {
+          selectionProbeSettledKind = "selection";
           editSourceText.value = state.text;
           writeInfoLog(
             `useVoiceFlowStore: edit mode activated (ax), selectedText length=${state.text.length}`,
           );
         } else if (state.kind === "noSelection") {
+          selectionProbeSettledKind = "noSelection";
           // AX 的明確否定是權威答案：若慢速後備已誤寫（整行複製），以此為準清掉
           editSourceText.value = null;
         } else if (state.kind === "unavailable") {
+          selectionProbeSettledKind = "unavailable";
           pendingClipboardSelectionCheck = true;
         }
       })
@@ -1130,9 +1141,28 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
             resolve();
             return;
           }
+          // 慢速 AX 在後備排程後才落地權威答案（selection / noSelection）：以 AX
+          // 為準，不再用剪貼簿後備覆寫，避免「無選取複製整行」誤判（#24）復發。
+          // 僅在 AX 未落地、或落地為 unavailable 時才真的走後備。
+          if (
+            selectionProbeSettledEpoch === recordingEpoch &&
+            selectionProbeSettledKind !== null &&
+            selectionProbeSettledKind !== "unavailable"
+          ) {
+            resolve();
+            return;
+          }
           invoke<string | null>("read_selected_text")
             .then((selectedText) => {
               if (fallbackEpoch !== recordingEpoch) return;
+              // AX 可能在 Cmd+C 往返期間才落地權威答案：提交前再驗一次
+              if (
+                selectionProbeSettledEpoch === recordingEpoch &&
+                selectionProbeSettledKind !== null &&
+                selectionProbeSettledKind !== "unavailable"
+              ) {
+                return;
+              }
               if (
                 selectedText &&
                 selectedText.trim().length > 0 &&
@@ -1344,10 +1374,22 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
         return;
       }
 
-      // 剪貼簿後備可能還在等按鍵放開（轉錄比後備快時）：判定模式前先等它完成
+      // 剪貼簿後備可能還在等按鍵放開（轉錄比後備快時）：判定模式前先等它。
+      // 加 timeout 防 read_selected_text 永不 settle（Rust 端卡死）拖住整條流程；
+      // await 後以 identity 清空、並重驗 epoch/abort，避免污染下一輪錄音或 ESC 後仍貼上。
       if (pendingSelectionCapture) {
-        await pendingSelectionCapture;
-        pendingSelectionCapture = null;
+        const capturePromise = pendingSelectionCapture;
+        const captureEpoch = recordingEpoch;
+        await Promise.race([
+          capturePromise,
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, PENDING_SELECTION_CAPTURE_TIMEOUT_MS);
+          }),
+        ]);
+        if (pendingSelectionCapture === capturePromise) {
+          pendingSelectionCapture = null;
+        }
+        if (recordingEpoch !== captureEpoch || isAborted.value) return;
       }
 
       // 編輯模式：語音是指令，選取文字是待處理內容

--- a/tests/unit/use-voice-flow-store.test.ts
+++ b/tests/unit/use-voice-flow-store.test.ts
@@ -525,6 +525,53 @@ describe("useVoiceFlowStore", () => {
       expect(mockInvoke).not.toHaveBeenCalledWith("read_selected_text");
     });
 
+    it("[P1] 慢速 AX 在後備排程後才回 noSelection：不得被剪貼簿整行複製誤判成編輯模式（#24 race）", async () => {
+      const axDeferred = createDeferredPromise<{
+        kind: string;
+        text: string | null;
+      }>();
+      const base = createMockInvokeHandler();
+      mockInvoke.mockImplementation(async (cmd: string, args?: unknown) => {
+        if (cmd === "read_selection_state") return axDeferred.promise;
+        // 編輯器「無選取時 Cmd+C 複製整行」→ 後備會撈回整行文字（bug 觸發源）
+        if (cmd === "read_selected_text") return "整行被複製的內容";
+        return base(cmd, args);
+      });
+
+      const store = useVoiceFlowStore();
+      await store.initialize();
+
+      triggerHotkeyEvent("hotkey:pressed");
+      await vi.waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("start_recording", {
+          deviceName: "",
+        });
+      });
+
+      // 停止：AX 尚未落地 → stop 流程保守排程剪貼簿後備
+      triggerHotkeyEvent("hotkey:released");
+      // stop_recording 在後備排程之後才被呼叫：等它出現即代表後備已排程好，
+      // 此時才讓 AX 落地權威 noSelection —— 精準命中「後備已排程 → AX 才回」的競態
+      await vi.waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("stop_recording");
+      });
+      axDeferred.resolvePromise({ kind: "noSelection", text: null });
+
+      // 一般聽寫結果應貼上，且全程不呼叫剪貼簿後備、不進編輯模式
+      // （AX 權威否定壓過「整行複製」）
+      await vi.waitFor(
+        () => {
+          expect(mockInvoke).toHaveBeenCalledWith("paste_text", {
+            text: "測試轉錄",
+            restoreClipboard: false,
+          });
+        },
+        { timeout: 3000 },
+      );
+      expect(store.isEditMode).toBe(false);
+      expect(mockInvoke).not.toHaveBeenCalledWith("read_selected_text");
+    });
+
     it("[P0] AX 回報 unavailable 應在停止錄音後走剪貼簿後備並進編輯模式", async () => {
       withSelectionState({ kind: "unavailable", text: null }, "後備選取的文字");
       const store = useVoiceFlowStore();


### PR DESCRIPTION
## What & why

Follow-up hardening for **A4 (macOS AX selection detection, upstream #69, merged in PR #23)**. A RubberDuck deep-review of the merged A4 surfaced 5 hot-path issues; a subsequent Council review then caught a regression in one of my fixes (see #5 below). Final state fixes 4 real issues cleanly.

## Fixes

1. **Sync command could block the main thread.** `read_selection_state` was a synchronous `#[tauri::command]` waiting up to 600ms. Tauri v2 runs sync commands on the main thread, so a hung AX server could delay the `play_start_sound` / `start_recording` invokes dispatched right after → clipped opening audio. Now `async` + `tauri::async_runtime::spawn_blocking`.

2. **Slow-AX-then-noSelection race re-introduced #24.** When AX hadn't settled by stop time, the clipboard fallback was scheduled conservatively; if AX then settled as authoritative `noSelection`, the fallback still fired and could set a whole line (copy-whole-line editors) as `editSourceText`, re-triggering false edit mode. The fallback now defers to an authoritative AX answer (fire-time + commit-time guard).

3. **`pendingSelectionCapture` await had no timeout / epoch / abort guard.** A never-settling `read_selected_text` could stall the flow; an ESC or new recording during the await could paste anyway or null a newer capture. Added `Promise.race` timeout (2s), identity-scoped clear, and epoch/abort re-check.

4. **Invalid CFRange misclassified as `noSelection`.** A sentinel range (`location: -1`) fell into the `Some(_)` arm and skipped the fallback. Now any negative `location`/`length` → `unavailable`.

5. **~~AX worker channel → rendezvous (capacity 0)~~ — REVERTED.** This was intended to reject stale queued requests, but Council review empirically proved it deterministically breaks the **first** AX read after every launch (lazily-spawned worker isn't parked in `recv()` when the caller `try_send`s → cold-start `unavailable` → clipboard fallback, reintroducing #24/#25 for the first use). Reverted to capacity 1 (the proven behavior from #23). The minor stale-queue this re-accepts is non-blocking, self-healing, and bounded by single-flight.

## Tests
- New deterministic vitest regression for the #2 noSelection race (fails on pre-fix code).
- New Rust unit test for `is_valid_selection_range`.

## Validation
- `vue-tsc` ✅ · `eslint src` ✅ (0 errors) · `cargo check`/`cargo test` (Windows) ✅ · `vitest` **562 pass** ✅
- macOS-gated internals validated via `rust-check (macos-latest)` CI.
- Council review: 4 fixes confirmed correct; #5 regression caught → reverted.
- ⚠️ Runtime AX behavior still needs a real Mac; CI validates compile + logic, not live GUI AX.