### PR TITLE
feat(models): add Gemini 3.1 Pro (Preview) with per-model request policy

### DIFF
--- a/src/lib/apiPricing.ts
+++ b/src/lib/apiPricing.ts
@@ -31,11 +31,12 @@ export function calculateChatCostCeiling(
   modelId: string = DEFAULT_LLM_MODEL_ID,
 ): number {
   const config = findLlmModelConfig(modelId);
-  // fallback 取全 registry 最貴的 outputCostPerMillion（gemini-3.5-flash $9/M），
-  // 維持「保證是上限」的不變量——查不到 config 時（如遺留的死 model id）不會低估
+  // fallback 取全 registry 最貴的 outputCostPerMillion（gemini-3.1-pro-preview
+  // $12/M，<200k tier）維持「保證是上限」的不變量——查不到 config 時（如遺留的
+  // 死 model id）不會低估。
   const maxCostPerToken = config
     ? Math.max(config.inputCostPerMillion, config.outputCostPerMillion) /
       1_000_000
-    : 0.000009;
+    : 0.000012;
   return totalTokens * maxCostPerToken;
 }

--- a/src/lib/llmProvider.ts
+++ b/src/lib/llmProvider.ts
@@ -328,14 +328,27 @@ function buildGeminiFetchParams(
   }
 
   const generationConfig: Record<string, unknown> = {};
-  if (request.temperature !== undefined)
+  // Gemini 3 官方強烈建議維持預設 temperature（1.0）；送非預設值在 Gemini 3 上
+  // 可能導致品質退化/迴圈。新加的 gemini-3.1-pro-preview 依此不送 temperature；
+  // 既有 flash 模型維持現行行為避免回歸（可另案評估是否一併對齊）。
+  if (
+    request.temperature !== undefined &&
+    request.model !== "gemini-3.1-pro-preview"
+  )
     generationConfig.temperature = request.temperature;
   if (request.maxTokens !== undefined)
     generationConfig.maxOutputTokens = request.maxTokens;
-  // Gemini 3.x 預設就會思考（medium）：文字整理不需要，壓到最低省延遲與 token。
-  // 欄位路徑與 enum 值出自 generateContent API 參考（ThinkingConfig.thinkingLevel）
-  if (request.model.startsWith("gemini-3")) {
-    generationConfig.thinkingConfig = { thinkingLevel: "MINIMAL" };
+  // Gemini 3.x thinkingConfig（generateContent，enum 大寫，值出自 API 參考）：
+  // 文字整理不需深度思考，壓低省延遲與 token。gemini-3.1-pro-preview 不支援
+  // MINIMAL（送了會 400），改用 LOW（預設 HIGH 太慢）；其餘 gemini-3* 用 MINIMAL。
+  const geminiThinkingLevel =
+    request.model === "gemini-3.1-pro-preview"
+      ? "LOW"
+      : request.model.startsWith("gemini-3")
+        ? "MINIMAL"
+        : undefined;
+  if (geminiThinkingLevel) {
+    generationConfig.thinkingConfig = { thinkingLevel: geminiThinkingLevel };
   }
   if (Object.keys(generationConfig).length > 0)
     body.generationConfig = generationConfig;

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -14,7 +14,8 @@ export type LlmModelId =
   | "gpt-5.4-nano"
   | "claude-haiku-4-5-20251001"
   | "gemini-3.5-flash"
-  | "gemini-3.1-flash-lite";
+  | "gemini-3.1-flash-lite"
+  | "gemini-3.1-pro-preview";
 
 // ── Whisper 模型（語音轉錄用）─────────────────────────────
 
@@ -138,6 +139,21 @@ export const LLM_MODEL_LIST: LlmModelConfig[] = [
     speedTps: 0,
     inputCostPerMillion: 0.25,
     outputCostPerMillion: 1.5,
+    freeQuotaRpd: 0,
+    freeQuotaTpd: 0,
+    isDefault: false,
+  },
+  {
+    // Preview 模型：Google 標為 preview，顯示名稱標明讓使用者知情。
+    // Pro 級最高品質；分層計價（<200k: $2/$12、>200k: $4/$18），此處採 <200k
+    // tier——本 App 請求（短逐字稿＋prompt）遠低於 200k tokens。
+    id: "gemini-3.1-pro-preview",
+    providerId: "gemini",
+    displayName: "Gemini 3.1 Pro (Preview)",
+    badgeKey: "settings.modelBadge.smartestSlow",
+    speedTps: 0,
+    inputCostPerMillion: 2.0,
+    outputCostPerMillion: 12.0,
     freeQuotaRpd: 0,
     freeQuotaTpd: 0,
     isDefault: false,

--- a/tests/unit/api-pricing.test.ts
+++ b/tests/unit/api-pricing.test.ts
@@ -3,6 +3,7 @@ import {
   calculateWhisperCostCeiling,
   calculateChatCostCeiling,
 } from "../../src/lib/apiPricing";
+import { LLM_MODEL_LIST } from "../../src/lib/modelRegistry";
 
 describe("apiPricing.ts", () => {
   // ==========================================================================
@@ -72,6 +73,19 @@ describe("apiPricing.ts", () => {
       // 預設模型 Qwen3.6 27B: 150 * 0.000003 = 0.00045
       const cost = calculateChatCostCeiling(150);
       expect(cost).toBeCloseTo(0.00045, 6);
+    });
+
+    it("[P1] 未知 model id 的 fallback 上限 ≥ registry 內任何模型（保證不低估）", () => {
+      // 不變量守衛：加入更貴的模型（如 Gemini 3.1 Pro $12/M）後，
+      // apiPricing.ts 的 fallback 天花板須同步 ≥ 最貴模型，否則遺留死 id 會被低估。
+      const unknownCeiling = calculateChatCostCeiling(
+        1_000_000,
+        "totally-dead-model-id",
+      );
+      for (const model of LLM_MODEL_LIST) {
+        const modelCost = calculateChatCostCeiling(1_000_000, model.id);
+        expect(unknownCeiling).toBeGreaterThanOrEqual(modelCost);
+      }
     });
   });
 });

--- a/tests/unit/llmProvider.test.ts
+++ b/tests/unit/llmProvider.test.ts
@@ -108,6 +108,18 @@ describe("llmProvider.ts", () => {
       expect(body.generationConfig.thinkingConfig.thinkingLevel).toBe("MINIMAL");
     });
 
+    it("[P0] Gemini 3.1 Pro Preview：thinkingLevel=LOW（不支援 MINIMAL→避免 400）且不送 temperature", () => {
+      const { init } = buildFetchParams(
+        "gemini",
+        { ...BASE_REQUEST, model: "gemini-3.1-pro-preview" },
+        TEST_API_KEY,
+      );
+      const body = JSON.parse(init.body as string);
+      expect(body.generationConfig.thinkingConfig.thinkingLevel).toBe("LOW");
+      // Gemini 3 官方建議維持預設 temperature；Pro 不送（BASE_REQUEST 帶 0.1）
+      expect(body.generationConfig.temperature).toBeUndefined();
+    });
+
     it("[P1] Gemini 非-3 模型：不加 thinkingConfig", () => {
       const { init } = buildFetchParams("gemini", BASE_REQUEST, TEST_API_KEY);
       const body = JSON.parse(init.body as string);

--- a/tests/unit/model-registry.test.ts
+++ b/tests/unit/model-registry.test.ts
@@ -40,6 +40,12 @@ describe("modelRegistry — 模型遷移", () => {
     it("[P0] 預設模型本身存在於 registry", () => {
       expect(findLlmModelConfig(DEFAULT_LLM_MODEL_ID)).toBeDefined();
     });
+
+    it("[P1] gemini-3.1-pro-preview（新增 Pro 級）存在且 providerId=gemini", () => {
+      const config = findLlmModelConfig("gemini-3.1-pro-preview");
+      expect(config).toBeDefined();
+      expect(config?.providerId).toBe("gemini");
+    });
   });
 
   describe("getEffectiveLlmModelId", () => {


### PR DESCRIPTION
## What & why

Batch 2 · Item 1. Adds **`gemini-3.1-pro-preview`** as a higher-quality Gemini option. Your fork already modernized Gemini to 3.x (A1, PR #18/#19) but exposed only two flash-tier models — this fills the **Pro-tier gap** you asked about. (Upstream has nothing newer; this is a fresh fork enhancement.)

Verified against Google's official docs (`ai.google.dev/gemini-api/docs/gemini-3`, 2026-07-13): exact ID, pricing, thinking levels, and temperature guidance.

## Changes
- **`modelRegistry.ts`**: add `gemini-3.1-pro-preview` (Preview label, `smartestSlow` badge, `$2/$12` using the `<200k` tier — this app's requests are far under 200k tokens).
- **`llmProvider.ts` (`buildGeminiFetchParams`)**: replace the blanket `startsWith("gemini-3")` with a **per-model policy**:
  - Pro does **not** support `thinkingLevel: MINIMAL` (would **400**) → send **`LOW`**; other `gemini-3*` keep `MINIMAL`.
  - Gemini 3 strongly recommends the **default temperature** → omit `temperature` for Pro; existing flash models unchanged (no regression to shipped behavior).
- **`apiPricing.ts`**: bump the unknown-model fallback ceiling `$9 → $12/M` so the "guaranteed cost ceiling" invariant still holds after adding the costlier Pro.

## Tests
- Pro → `thinkingLevel: LOW` **and no `temperature`** (prevents the 400 regression).
- Pro present in registry with `providerId: gemini`.
- **Pricing ceiling invariant**: fallback ≥ every registry model's cost (guards future costlier additions).
- Full suite **565 pass**.

## Notes
- Per **D-seq (先不發版)**: a real API-key **live smoke test is deferred to release**. This PR validates request-body shape + typing + CI; it does not make live Gemini calls.
- Existing `gemini-3.5-flash` / `gemini-3.1-flash-lite` IDs re-confirmed valid against official docs.