### PR TITLE
perf(a2): lazy-load opencc-js + zh-TW conversion integration tests

### DIFF
--- a/src/lib/simplifiedToTraditional.ts
+++ b/src/lib/simplifiedToTraditional.ts
@@ -4,24 +4,53 @@
  * 背景（#39）：Whisper 對中文預設輸出簡體，而使用者若選繁中，會期待繁體輸出。
  * SayIt 過去沒有確定性的簡→繁轉換（只靠 AI 整理偶爾順手轉、不穩定）。
  * 這裡用 opencc-js 做字元級（Taiwan 標準）轉換，只在轉譯語言解析為 zh-TW 時套用。
+ * opencc-js（~1.19MB 字典）採**惰性動態載入**、不進初始 bundle；載入/轉換失敗 fail-open。
  *
  * 用 `to: "tw"`（字元級台灣正體）而非 `"twp"`（含詞彙/慣用語轉換）：
  * 只轉字、不改用詞，避免把使用者原本的措辭改掉。
  */
-import { Converter } from "opencc-js";
+type ConvertFn = (text: string) => string;
 
-let convert: ((text: string) => string) | null = null;
+// 快取「載入 converter」的 promise：成功後重用；失敗（chunk/asset 損毀、
+// updater 不一致等）時重置快取，讓下次呼叫有機會重試，本次則 fail-open 回原文。
+let converterPromise: Promise<ConvertFn> | null = null;
 
-/** 惰性建立 converter（載入字典有成本，建立一次即可重用）。 */
-function getConverter(): (text: string) => string {
-  if (!convert) {
-    convert = Converter({ from: "cn", to: "tw" });
-  }
-  return convert;
+async function loadConverter(): Promise<ConvertFn> {
+  // 動態載入：~1.19MB 字典成獨立 chunk，不進初始 bundle。
+  const { Converter } = await import("opencc-js");
+  // 用 to:"tw"（字元級台灣正體）非 "twp"（含詞彙/慣用語）：只轉字、不改用詞。
+  return Converter({ from: "cn", to: "tw" });
 }
 
-/** 把簡體中文轉成繁體（台灣）。空字串原樣返回。 */
-export function convertSimplifiedToTraditional(text: string): string {
+function getConverter(): Promise<ConvertFn> {
+  if (!converterPromise) {
+    converterPromise = loadConverter().catch((err) => {
+      // 重置快取讓下次重試；本次由呼叫端 fail-open 回原文。
+      converterPromise = null;
+      throw err;
+    });
+  }
+  return converterPromise;
+}
+
+/**
+ * 把簡體中文轉成繁體（台灣）。空字串原樣返回。
+ * 惰性載入 opencc-js；載入或轉換失敗時 **fail-open**：記 content-free warning
+ * 並回傳原字串，絕不讓非必要的字元轉換弄垮整條 paste / retry 流程。
+ */
+export async function convertSimplifiedToTraditional(
+  text: string,
+): Promise<string> {
   if (!text) return text;
-  return getConverter()(text);
+  try {
+    const convert = await getConverter();
+    return convert(text);
+  } catch (err) {
+    // content-free：只記錯誤訊息、不記文字內容。
+    console.warn(
+      "[simplifiedToTraditional] opencc-js load/convert failed; returning raw text:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return text;
+  }
 }

--- a/src/lib/transcriptTransforms.ts
+++ b/src/lib/transcriptTransforms.ts
@@ -19,14 +19,15 @@ export function resolveEffectiveTranscriptionLocale(
 /**
  * 轉錄原文落地前的文字轉換。
  * 目前只做：有效轉譯語言為繁中（zh-TW）時，把 Whisper 的簡體輸出轉成繁體。
- * 其餘語言（或空字串）原樣返回。
+ * 其餘語言（或空字串）原樣返回——此路徑**不會**觸發 opencc 的惰性載入。
+ * 因 opencc 改為動態載入，本函式為 async；非 zh-TW / 空字串仍同步解析。
  */
-export function applyTranscriptTextTransforms(
+export async function applyTranscriptTextTransforms(
   rawText: string,
   effectiveLocale: string,
-): string {
+): Promise<string> {
   if (!rawText) return rawText;
   return effectiveLocale === "zh-TW"
-    ? convertSimplifiedToTraditional(rawText)
+    ? await convertSimplifiedToTraditional(rawText)
     : rawText;
 }

--- a/src/stores/useHistoryStore.ts
+++ b/src/stores/useHistoryStore.ts
@@ -723,7 +723,7 @@ export const useHistoryStore = defineStore("history", () => {
     }
 
     // #39：同主路徑，重新辨識後也套用簡→繁（寫回 raw_text 前）
-    result.rawText = applyTranscriptTextTransforms(
+    result.rawText = await applyTranscriptTextTransforms(
       result.rawText,
       resolveEffectiveTranscriptionLocale(
         settingsStore.selectedTranscriptionLocale,

--- a/src/stores/useVoiceFlowStore.ts
+++ b/src/stores/useVoiceFlowStore.ts
@@ -1285,7 +1285,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
       audioFilePath = await saveRecordingFilePromise;
 
       // #39：轉譯語言為繁中時，把 Whisper 簡體輸出轉繁體（落地前一次到位）
-      result.rawText = applyTranscriptTextTransforms(
+      result.rawText = await applyTranscriptTextTransforms(
         result.rawText,
         resolveEffectiveTranscriptionLocale(
           settingsStore.selectedTranscriptionLocale,
@@ -1734,7 +1734,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
       if (isAborted.value) return;
 
       // #39：同主路徑，重送轉錄後也套用簡→繁
-      result.rawText = applyTranscriptTextTransforms(
+      result.rawText = await applyTranscriptTextTransforms(
         result.rawText,
         resolveEffectiveTranscriptionLocale(
           settingsStore.selectedTranscriptionLocale,

--- a/tests/unit/simplified-to-traditional-failopen.test.ts
+++ b/tests/unit/simplified-to-traditional-failopen.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// 隔離檔：驗證 opencc-js 惰性載入 / converter 失敗時 convertSimplifiedToTraditional
+// 會 fail-open 回傳原文而非 throw（RubberDuck 要求的 import/converter 失敗覆蓋）。
+// 用 vi.doMock + resetModules 避免污染其他測試對真實 opencc 的依賴。
+
+describe("convertSimplifiedToTraditional — fail-open", () => {
+  afterEach(() => {
+    vi.doUnmock("opencc-js");
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("[P1] converter 建立失敗時回傳原文、不 throw、不噴文字內容", async () => {
+    vi.resetModules();
+    vi.doMock("opencc-js", () => ({
+      Converter: () => {
+        throw new Error("simulated opencc failure");
+      },
+    }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { convertSimplifiedToTraditional } = await import(
+      "../../src/lib/simplifiedToTraditional"
+    );
+
+    const input = "请把会议改到星期五并通知所有人";
+    const result = await convertSimplifiedToTraditional(input);
+
+    // fail-open：原文原樣返回（未轉換）
+    expect(result).toBe(input);
+    // 有記 warning，但不含文字內容（content-free）
+    expect(warnSpy).toHaveBeenCalled();
+    const loggedArgs = warnSpy.mock.calls.flat().join(" ");
+    expect(loggedArgs).not.toContain(input);
+  });
+
+  it("[P1] 失敗後快取重置：下次呼叫會重試（成功 mock 下可正常轉換）", async () => {
+    // 先一次失敗
+    vi.resetModules();
+    vi.doMock("opencc-js", () => ({
+      Converter: () => {
+        throw new Error("first failure");
+      },
+    }));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mod1 = await import("../../src/lib/simplifiedToTraditional");
+    expect(await mod1.convertSimplifiedToTraditional("请")).toBe("请");
+
+    // 換成成功的 mock（模擬字典就緒後重試成功）——需重置模組讓快取清空
+    vi.doUnmock("opencc-js");
+    vi.resetModules();
+    vi.doMock("opencc-js", () => ({
+      Converter: () => (t: string) => t.replace("请", "請"),
+    }));
+    const mod2 = await import("../../src/lib/simplifiedToTraditional");
+    expect(await mod2.convertSimplifiedToTraditional("请")).toBe("請");
+  });
+});

--- a/tests/unit/simplified-to-traditional-failopen.test.ts
+++ b/tests/unit/simplified-to-traditional-failopen.test.ts
@@ -35,25 +35,23 @@ describe("convertSimplifiedToTraditional — fail-open", () => {
     expect(loggedArgs).not.toContain(input);
   });
 
-  it("[P1] 失敗後快取重置：下次呼叫會重試（成功 mock 下可正常轉換）", async () => {
-    // 先一次失敗
+  it("[P1] 失敗後快取重置：同一模組實例下次呼叫會重試（真正覆蓋 reset 邏輯）", async () => {
     vi.resetModules();
+    let calls = 0;
     vi.doMock("opencc-js", () => ({
       Converter: () => {
-        throw new Error("first failure");
+        // 第一次建立 converter 失敗、第二次成功——驗證 converterPromise 被重置後會重試
+        if (++calls === 1) throw new Error("first failure");
+        return (t: string) => t.replace("请", "請");
       },
     }));
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    const mod1 = await import("../../src/lib/simplifiedToTraditional");
-    expect(await mod1.convertSimplifiedToTraditional("请")).toBe("请");
 
-    // 換成成功的 mock（模擬字典就緒後重試成功）——需重置模組讓快取清空
-    vi.doUnmock("opencc-js");
-    vi.resetModules();
-    vi.doMock("opencc-js", () => ({
-      Converter: () => (t: string) => t.replace("请", "請"),
-    }));
-    const mod2 = await import("../../src/lib/simplifiedToTraditional");
-    expect(await mod2.convertSimplifiedToTraditional("请")).toBe("請");
+    const mod = await import("../../src/lib/simplifiedToTraditional");
+    // 第一次：converter 建立失敗 → fail-open 回原文，且 converterPromise 被重置為 null
+    expect(await mod.convertSimplifiedToTraditional("请")).toBe("请");
+    // 第二次：若少了 reset，會拿到快取的 rejected promise 續 fail-open 回 "请"；
+    // 有 reset 才會重建、命中成功 mock → "請"（此斷言即 reset 邏輯的守衛）
+    expect(await mod.convertSimplifiedToTraditional("请")).toBe("請");
   });
 });

--- a/tests/unit/transcript-transforms.test.ts
+++ b/tests/unit/transcript-transforms.test.ts
@@ -6,18 +6,18 @@ import {
 } from "../../src/lib/transcriptTransforms";
 
 describe("simplifiedToTraditional", () => {
-  it("[P0] 簡體轉台灣正體", () => {
-    expect(convertSimplifiedToTraditional("请把会议改到星期五并通知所有人")).toBe(
-      "請把會議改到星期五並通知所有人",
-    );
+  it("[P0] 簡體轉台灣正體", async () => {
+    expect(
+      await convertSimplifiedToTraditional("请把会议改到星期五并通知所有人"),
+    ).toBe("請把會議改到星期五並通知所有人");
   });
 
-  it("[P0] 已是繁體 → 原樣返回", () => {
-    expect(convertSimplifiedToTraditional("已經是繁體")).toBe("已經是繁體");
+  it("[P0] 已是繁體 → 原樣返回", async () => {
+    expect(await convertSimplifiedToTraditional("已經是繁體")).toBe("已經是繁體");
   });
 
-  it("[P1] 空字串原樣返回", () => {
-    expect(convertSimplifiedToTraditional("")).toBe("");
+  it("[P1] 空字串原樣返回", async () => {
+    expect(await convertSimplifiedToTraditional("")).toBe("");
   });
 });
 
@@ -34,18 +34,25 @@ describe("resolveEffectiveTranscriptionLocale", () => {
 });
 
 describe("applyTranscriptTextTransforms", () => {
-  it("[P0] zh-TW → 簡體轉繁體", () => {
+  it("[P0] zh-TW → 簡體轉繁體", async () => {
     expect(
-      applyTranscriptTextTransforms("请把会议改到星期五并通知所有人", "zh-TW"),
+      await applyTranscriptTextTransforms(
+        "请把会议改到星期五并通知所有人",
+        "zh-TW",
+      ),
     ).toBe("請把會議改到星期五並通知所有人");
   });
 
-  it("[P0] 非 zh-TW → 不轉換（zh-CN 原樣）", () => {
-    expect(applyTranscriptTextTransforms("请把会议", "zh-CN")).toBe("请把会议");
-    expect(applyTranscriptTextTransforms("请把会议", "en")).toBe("请把会议");
+  it("[P0] 非 zh-TW → 不轉換（zh-CN 原樣，不觸發 opencc 載入）", async () => {
+    expect(await applyTranscriptTextTransforms("请把会议", "zh-CN")).toBe(
+      "请把会议",
+    );
+    expect(await applyTranscriptTextTransforms("请把会议", "en")).toBe(
+      "请把会议",
+    );
   });
 
-  it("[P1] 空字串原樣返回", () => {
-    expect(applyTranscriptTextTransforms("", "zh-TW")).toBe("");
+  it("[P1] 空字串原樣返回", async () => {
+    expect(await applyTranscriptTextTransforms("", "zh-TW")).toBe("");
   });
 });

--- a/tests/unit/use-voice-flow-store.test.ts
+++ b/tests/unit/use-voice-flow-store.test.ts
@@ -93,6 +93,8 @@ const {
       isSmartDictionaryEnabled: false,
       isCopyTranscriptionToClipboardEnabled: true,
       whisperLanguageCode: "zh" as string | null,
+      selectedTranscriptionLocale: "auto" as string,
+      selectedLocale: "en" as string,
     },
     mockVocabularyState: {
       termList: [] as Array<{
@@ -205,6 +207,12 @@ vi.mock("../../src/stores/useSettingsStore", () => ({
     },
     get selectedWhisperModelId() {
       return mockSettingsState.selectedWhisperModelId;
+    },
+    get selectedTranscriptionLocale() {
+      return mockSettingsState.selectedTranscriptionLocale;
+    },
+    get selectedLocale() {
+      return mockSettingsState.selectedLocale;
     },
     get isMuteOnRecordingEnabled() {
       return mockSettingsState.isMuteOnRecordingEnabled;
@@ -342,6 +350,8 @@ describe("useVoiceFlowStore", () => {
     mockSettingsState.isSoundEffectsEnabled = true;
     mockSettingsState.isSmartDictionaryEnabled = false;
     mockSettingsState.whisperLanguageCode = "zh";
+    mockSettingsState.selectedTranscriptionLocale = "auto";
+    mockSettingsState.selectedLocale = "en";
     mockVocabularyState.termList = [];
     mockVocabularyState.getTopTermListByWeight
       .mockClear()
@@ -599,6 +609,76 @@ describe("useVoiceFlowStore", () => {
         { timeout: 3000 },
       );
       expect(mockInvoke).toHaveBeenCalledWith("read_selected_text");
+    });
+  });
+
+  describe("簡→繁轉換整合（#39 · a2 端到端）", () => {
+    const SIMPLIFIED = "请把会议改到星期五并通知所有人";
+    const TRADITIONAL = "請把會議改到星期五並通知所有人";
+
+    it("[P1] 轉譯語言為 zh-TW：Whisper 簡體輸出應在流程中轉繁體後再送 AI 整理", async () => {
+      mockSettingsState.selectedTranscriptionLocale = "zh-TW";
+      mockInvoke.mockImplementation(
+        createMockInvokeHandler({
+          transcribeResult: {
+            rawText: SIMPLIFIED,
+            transcriptionDurationMs: 320,
+            noSpeechProbability: 0.01,
+          },
+        }),
+      );
+
+      const store = useVoiceFlowStore();
+      await store.initialize();
+
+      triggerHotkeyEvent("hotkey:pressed");
+      await vi.waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("start_recording", {
+          deviceName: "",
+        });
+      });
+      triggerHotkeyEvent("hotkey:released");
+
+      // 轉換發生在 enhance 之前：enhancer 應收到繁體版本（>10 字走 AI 整理）
+      await vi.waitFor(() => {
+        expect(mockEnhanceText).toHaveBeenCalledWith(
+          TRADITIONAL,
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+    });
+
+    it("[P1] 轉譯語言非 zh-TW（zh-CN）：不轉換，簡體原樣送 AI 整理", async () => {
+      mockSettingsState.selectedTranscriptionLocale = "zh-CN";
+      mockInvoke.mockImplementation(
+        createMockInvokeHandler({
+          transcribeResult: {
+            rawText: SIMPLIFIED,
+            transcriptionDurationMs: 320,
+            noSpeechProbability: 0.01,
+          },
+        }),
+      );
+
+      const store = useVoiceFlowStore();
+      await store.initialize();
+
+      triggerHotkeyEvent("hotkey:pressed");
+      await vi.waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("start_recording", {
+          deviceName: "",
+        });
+      });
+      triggerHotkeyEvent("hotkey:released");
+
+      await vi.waitFor(() => {
+        expect(mockEnhanceText).toHaveBeenCalledWith(
+          SIMPLIFIED,
+          expect.anything(),
+          expect.anything(),
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## What & why
Batch 2 - Item 2 (a2-lazy-opencc + a2-integration-test). Two low-risk refinements to the merged A2 (simplified->traditional, #39):
1. Move opencc-js ~1.19MB dictionary out of the initial bundle via dynamic import (faster startup).
2. Add end-to-end coverage that conversion actually fires in the store flow.

## Changes
- **simplifiedToTraditional.ts**: dynamic `import("opencc-js")` + cached converter promise. `convertSimplifiedToTraditional` is now async and **fail-open** (import/converter failure -> content-free warning + return raw text; failed load resets cache to retry).
- **transcriptTransforms.ts**: `applyTranscriptTextTransforms` async; non-zh-TW/empty never triggers the opencc load.
- 3 call sites now await (useVoiceFlowStore main + resend, useHistoryStore reEnhance). No store-init preload.

## Tests
- Transform tests made async; new isolated fail-open test (mocked opencc failure -> raw text, content-free log, cache-reset-retry); two store-level integration tests (zh-TW converts before enhance; non-zh-TW passes through).

## Verification
- `vite build` splits opencc into a separate `full-*.js` chunk (1.15MB) out of index (426KB)/main-window (94KB) entries. vitest **569 pass** (+4), vue-tsc, eslint clean.