### PR TITLE
feat(a5): semantic-drift shadow observation + resend length guard

### DIFF
--- a/src/lib/semanticDriftObserver.ts
+++ b/src/lib/semanticDriftObserver.ts
@@ -1,0 +1,43 @@
+/**
+ * a5-B「shadow 觀測」：把既有但未接線的 `detectSemanticDrift` 接進 AI 整理流程，
+ * 但**完全不改變任何貼上/退回行為**——只在偵測到語意漂移時記一筆 content-free log。
+ *
+ * 背景：`detectSemanticDrift` 是字元 bigram 包含率、非語意相似度；0.2 門檻未證明
+ * 適用中文「口語→書面語」改寫（合法改寫也可能低於門檻 → false positive）。因此在
+ * 蒐集到 labeled corpus、量化 false-positive 率並通過 promotion gate 前，只做觀測、
+ * 不主動退回。log 僅含 content-free 欄位（ratio、長度、locale、prompt 模式、
+ * provider/model、would-fallback），**絕不記文字內容**（可能被 captureError 上報）。
+ */
+import { detectSemanticDrift } from "./hallucinationDetector";
+import { logInfoLine } from "./logger";
+
+export type SemanticDriftPath = "main" | "resend" | "history";
+
+export interface SemanticDriftObservationMeta {
+  locale?: string;
+  promptMode?: string;
+  provider?: string;
+  model?: string;
+}
+
+/**
+ * 觀測一次整理的語意漂移。偵測到漂移（若啟用主動退回則會 fallback）時記一筆 log。
+ * enhanced === raw（例如長度爆炸已 fallback 回原文）時 overlap=1、天然不觸發。
+ */
+export function observeSemanticDrift(
+  rawText: string,
+  enhancedText: string,
+  path: SemanticDriftPath,
+  meta: SemanticDriftObservationMeta = {},
+): void {
+  const drift = detectSemanticDrift(rawText, enhancedText);
+  if (!drift.isDrift) return;
+  logInfoLine(
+    `[semantic-drift-shadow] path=${path} ` +
+      `overlapRatio=${drift.overlapRatio.toFixed(3)} ` +
+      `rawLen=${rawText.length} enhancedLen=${enhancedText.length} ` +
+      `locale=${meta.locale ?? "?"} promptMode=${meta.promptMode ?? "?"} ` +
+      `provider=${meta.provider ?? "?"} model=${meta.model ?? "?"} ` +
+      `wouldFallback=true`,
+  );
+}

--- a/src/stores/useHistoryStore.ts
+++ b/src/stores/useHistoryStore.ts
@@ -25,6 +25,7 @@ import {
   type EnhanceWithGuardResult,
 } from "../lib/enhancer";
 import { detectHallucination } from "../lib/hallucinationDetector";
+import { observeSemanticDrift } from "../lib/semanticDriftObserver";
 import {
   applyTranscriptTextTransforms,
   resolveEffectiveTranscriptionLocale,
@@ -831,6 +832,13 @@ export const useHistoryStore = defineStore("history", () => {
     if (enhanceResult.wasAnomalous) {
       return { ok: false, errorKey: "history.reEnhanceFailed" };
     }
+
+    // a5-B shadow：觀測語意漂移（不改行為）
+    observeSemanticDrift(record.rawText, enhanceResult.text, "history", {
+      locale: settingsStore.selectedLocale,
+      provider: llmCfg.provider,
+      model: llmCfg.modelId,
+    });
 
     const db = getDatabase();
     const res = await db.execute(UPDATE_ON_REENHANCE_SQL, [

--- a/src/stores/useVoiceFlowStore.ts
+++ b/src/stores/useVoiceFlowStore.ts
@@ -13,7 +13,8 @@ import {
 } from "../lib/errorUtils";
 import { captureError } from "../lib/sentry";
 import { logInfoLine, logErrorLine } from "../lib/logger";
-import { enhanceText, buildSystemPrompt } from "../lib/enhancer";
+import { enhanceText, enhanceWithAnomalyGuard, buildSystemPrompt } from "../lib/enhancer";
+import { observeSemanticDrift } from "../lib/semanticDriftObserver";
 import { getEditModePromptForLocale } from "../i18n/prompts";
 import type { SupportedLocale } from "../i18n/languageConfig";
 import { analyzeCorrections } from "../lib/vocabularyAnalyzer";
@@ -1470,6 +1471,13 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
             enhanceResult = { ...enhanceResult, text: result.rawText };
           }
 
+          // a5-B shadow：觀測語意漂移（不改任何行為；長度 fallback 後 text===raw 天然不觸發）
+          observeSemanticDrift(result.rawText, enhanceResult.text, "main", {
+            locale: settingsStore.selectedLocale,
+            provider: llmCfg.provider,
+            model: llmCfg.modelId,
+          });
+
           const enhancementDurationMs =
             performance.now() - enhancementStartTime;
 
@@ -1789,16 +1797,27 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
           }
 
           const enhancementTermList = whisperTermList;
-          const enhanceResult = await enhanceText(result.rawText, llmCfg.apiKey, {
-            systemPrompt: settingsStore.getAiPrompt(),
-            vocabularyTermList:
-              enhancementTermList.length > 0 ? enhancementTermList : undefined,
-            modelId: llmCfg.modelId,
-            provider: llmCfg.provider,
-            azure: llmCfg.azure,
-            signal: abortController?.signal,
-          });
+          const enhanceResult = await enhanceWithAnomalyGuard(
+            result.rawText,
+            llmCfg.apiKey,
+            {
+              systemPrompt: settingsStore.getAiPrompt(),
+              vocabularyTermList:
+                enhancementTermList.length > 0 ? enhancementTermList : undefined,
+              modelId: llmCfg.modelId,
+              provider: llmCfg.provider,
+              azure: llmCfg.azure,
+              signal: abortController?.signal,
+            },
+          );
           if (isAborted.value) return;
+
+          // a5-B shadow：觀測語意漂移（不改行為）
+          observeSemanticDrift(result.rawText, enhanceResult.text, "resend", {
+            locale: settingsStore.selectedLocale,
+            provider: llmCfg.provider,
+            model: llmCfg.modelId,
+          });
 
           const enhancementDurationMs =
             performance.now() - enhancementStartTime;
@@ -1810,7 +1829,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
             recordingDurationMs,
             transcriptionDurationMs: result.transcriptionDurationMs,
             enhancementDurationMs,
-            wasEnhanced: true,
+            wasEnhanced: !enhanceResult.wasAnomalous,
             audioFilePath: filePath,
             status: "success",
           });
@@ -1836,7 +1855,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
                 result.transcriptionDurationMs,
               ),
               enhancementDurationMs: Math.round(enhancementDurationMs),
-              wasEnhanced: true,
+              wasEnhanced: !enhanceResult.wasAnomalous,
               charCount: result.rawText.length,
             })
             .then(() => {

--- a/tests/unit/semantic-drift-observer.test.ts
+++ b/tests/unit/semantic-drift-observer.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockLogInfoLine = vi.fn();
+vi.mock("../../src/lib/logger", () => ({
+  logInfoLine: (msg: string) => mockLogInfoLine(msg),
+}));
+
+import { observeSemanticDrift } from "../../src/lib/semanticDriftObserver";
+
+describe("observeSemanticDrift (a5-B shadow 觀測)", () => {
+  beforeEach(() => {
+    mockLogInfoLine.mockClear();
+  });
+
+  it("[P1] 偵測到語意漂移時記一筆 content-free log（不含任何文字內容）", () => {
+    const raw = "把會議改到星期五並通知大家準時出席";
+    // 與 raw 完全無關 → bigram 重疊近 0 → drift
+    const enhanced = "今天陽光普照適合出門散步順便買杯咖啡";
+
+    observeSemanticDrift(raw, enhanced, "main", {
+      locale: "zh-TW",
+      promptMode: "minimal",
+      provider: "groq",
+      model: "qwen/qwen3.6-27b",
+    });
+
+    expect(mockLogInfoLine).toHaveBeenCalledTimes(1);
+    const msg = mockLogInfoLine.mock.calls[0][0] as string;
+    expect(msg).toContain("[semantic-drift-shadow]");
+    expect(msg).toContain("path=main");
+    expect(msg).toContain("wouldFallback=true");
+    expect(msg).toContain("provider=groq");
+    // content-free：絕不含原文或整理後文字
+    expect(msg).not.toContain(raw);
+    expect(msg).not.toContain(enhanced);
+  });
+
+  it("[P1] 無漂移（enhanced 貼近 raw）時不記 log、不改任何行為", () => {
+    const raw = "把會議改到星期五並通知大家";
+    observeSemanticDrift(raw, raw, "resend", {});
+    expect(mockLogInfoLine).not.toHaveBeenCalled();
+  });
+
+  it("[P2] 長度守衛已 fallback（enhanced === raw）的情境天然不觸發", () => {
+    const raw = "這是一段夠長的測試逐字稿內容";
+    observeSemanticDrift(raw, raw, "history", { provider: "azure" });
+    expect(mockLogInfoLine).not.toHaveBeenCalled();
+  });
+
+  it("[P2] 極短原文（< 門檻）不判定 drift", () => {
+    observeSemanticDrift("你好", "完全不同的內容啦", "main", {});
+    expect(mockLogInfoLine).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/use-voice-flow-store.test.ts
+++ b/tests/unit/use-voice-flow-store.test.ts
@@ -144,6 +144,14 @@ vi.mock("../../src/lib/enhancer", () => {
   }
   return {
     enhanceText: mockEnhanceText,
+    enhanceWithAnomalyGuard: async (
+      rawText: string,
+      apiKey: string,
+      options?: unknown,
+    ) => {
+      const r = await mockEnhanceText(rawText, apiKey, options);
+      return { text: r.text, usage: r.usage ?? null, wasAnomalous: false };
+    },
     buildSystemPrompt: (basePrompt: string) => basePrompt,
     EnhancerApiError,
   };

--- a/tests/unit/use-voice-flow-store.test.ts
+++ b/tests/unit/use-voice-flow-store.test.ts
@@ -2316,6 +2316,43 @@ describe("useVoiceFlowStore", () => {
       expect(updateParams.processedText).toBeNull();
     });
 
+    it("[P1] 重送時原文達整理門檻應走 enhanceWithAnomalyGuard、貼整理後文字、wasEnhanced=true（a5 piece B）", async () => {
+      const store = useVoiceFlowStore();
+      await store.initialize();
+
+      await setupFailedTranscription(store);
+      expect(store.canRetry).toBe(true);
+
+      // 原文 >= enhancementThresholdCharCount(10) → 重送走 AI 整理（含長度守衛）
+      mockInvoke.mockImplementation(
+        createMockInvokeHandler({
+          retranscribeResult: {
+            rawText: "這是一段夠長需要整理的重送逐字稿內容",
+            transcriptionDurationMs: 350,
+            noSpeechProbability: 0.02,
+          },
+        }),
+      );
+
+      await store.handleRetryTranscription();
+
+      // 非異常 → enhanceWithAnomalyGuard 回整理後文字，貼上該文字
+      await vi.waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("paste_text", {
+          text: "AI 整理後的書面語文字",
+          restoreClipboard: false,
+        });
+      });
+
+      await vi.waitFor(() => {
+        expect(mockUpdateTranscriptionOnRetrySuccess).toHaveBeenCalledTimes(1);
+      });
+      const updateParams =
+        mockUpdateTranscriptionOnRetrySuccess.mock.calls[0][0];
+      expect(updateParams.processedText).toBe("AI 整理後的書面語文字");
+      expect(updateParams.wasEnhanced).toBe(true);
+    });
+
     it("[P0] 重送失敗（空轉錄）不再提供重送按鈕", async () => {
       const store = useVoiceFlowStore();
       await store.initialize();


### PR DESCRIPTION
## What & why
Batch 2 - Item 5 (a5-drift-wiring, decision **a5-B: observe first**). Two separable pieces from the a5 review:

### 1. Semantic-drift SHADOW observation (behavior-neutral)
The existing-but-**unwired** `detectSemanticDrift` is now called after enhancement in all **3 paths** (main, resend, history `reEnhanceRecord`) via a new `observeSemanticDrift` helper. It **only logs a content-free line** (overlapRatio, lengths, locale, promptMode, provider/model, `wouldFallback`) when drift is detected — it does **NOT** change what gets pasted.

**Why observe-only:** `detectSemanticDrift` is char-bigram containment, not semantic similarity; the `0.2` threshold is unproven for zh **casual→formal** rewriting (legitimate rewrites can score below it — RubberDuck showed real examples at 0.182/0.067), so active fallback would risk high false positives. This gathers data to calibrate a labeled corpus + a quantitative promotion gate before any active mode.

### 2. Resend length-explosion guard (real gap fix)
The **resend** path called `enhanceText` with **no anomaly guard**, unlike main (inline retry+fallback) and history. It now uses the shared, tested `enhanceWithAnomalyGuard`, and `wasEnhanced` reflects `!wasAnomalous`. Closes the resend anomaly-guard gap RubberDuck flagged.

## Safety
- **Content-free logging only** — never logs user text (verified by test).
- Fallback case (`enhanced === raw`) → overlap 1 → naturally no log.

## Tests
- New `observeSemanticDrift` unit test (logs on drift + content-free; no log when no drift / too-short / fallback).
- Enhancer mock gains `enhanceWithAnomalyGuard`; existing 67 voice-flow + 11 history-retry tests still pass.
- **vitest 583 pass**, vue-tsc, eslint clean.

No behavior change to pasting (piece 1); piece 2 gives resend the same protection main/history already have.