### PR TITLE
feat(guide): 功能介紹頁最上面顯示當下版本更新亮點

### DIFF
--- a/.claude/skills/sayit-release/SKILL.md
+++ b/.claude/skills/sayit-release/SKILL.md
@@ -160,9 +160,11 @@ SayIt 版本更新紀錄。
 
 升級彈窗由 Dashboard 啟動時 `consumeUpgradeNotice()` 觸發，比對 `lastSeenVersion`（存在 tauri-plugin-store）和 `__APP_VERSION__`（build-time 從 package.json 注入）。不相等就顯示。
 
+> ⚠️ `mainApp.upgradeNotice.itemN` 除了升級彈窗，也被「功能介紹」頁（`/guide`，`FeatureGuideView.vue`）當作「本次更新內容（v{version}）」卡片顯示——且該卡片一律可見、並標上當下版本號。因此每次發版都必須同步替換這 5 語系內容，否則 `/guide` 會在新版本號下顯示上一版的舊亮點。
+
 需要動 7 個檔案：
 1. `src/MainApp.vue`：`upgradeNoticeItemCount` 常數（控制顯示幾個 item）
-2. `src/i18n/locales/zh-TW.json`：`mainView.upgradeNotice` 區塊
+2. `src/i18n/locales/zh-TW.json`：`mainApp.upgradeNotice` 區塊
 3. `src/i18n/locales/zh-CN.json`：同上
 4. `src/i18n/locales/en.json`：同上
 5. `src/i18n/locales/ja.json`：同上
@@ -214,7 +216,7 @@ SayIt 版本更新紀錄。
 ④ skill 翻譯 4 語系（zh-CN / en / ja / ko）
 ⑤ 把整組 upgradeNotice（5 語系 × N 個 item）展示給使用者遷訂
 ⑥ 使用者 OK 後實際 Edit 6 個檔案：
-   - 5 個 .json 的 mainView.upgradeNotice 區塊
+   - 5 個 .json 的 mainApp.upgradeNotice 區塊
    - MainApp.vue 的 upgradeNoticeItemCount
 ```
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -507,6 +507,9 @@
     }
   },
   "featureGuide": {
+    "whatsNew": {
+      "title": "What's new in v{version}"
+    },
     "subtitle": "Here are all available features in SayIt to help you get started.",
     "voiceInput": {
       "title": "Voice Input",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -507,6 +507,9 @@
     }
   },
   "featureGuide": {
+    "whatsNew": {
+      "title": "今回のアップデート内容（v{version}）"
+    },
     "subtitle": "SayIt で利用できるすべての機能を紹介します。",
     "voiceInput": {
       "title": "音声入力",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -507,6 +507,9 @@
     }
   },
   "featureGuide": {
+    "whatsNew": {
+      "title": "이번 업데이트 내용 (v{version})"
+    },
     "subtitle": "SayIt에서 사용할 수 있는 모든 기능을 소개합니다.",
     "voiceInput": {
       "title": "음성 입력",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -507,6 +507,9 @@
     }
   },
   "featureGuide": {
+    "whatsNew": {
+      "title": "本次更新亮点（v{version}）"
+    },
     "subtitle": "以下是 SayIt 所有可用的操作功能，帮助你快速上手。",
     "voiceInput": {
       "title": "语音输入",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -507,6 +507,9 @@
     }
   },
   "featureGuide": {
+    "whatsNew": {
+      "title": "本次更新重點（v{version}）"
+    },
     "subtitle": "以下是 SayIt 所有可用的操作功能，幫助你快速上手。",
     "voiceInput": {
       "title": "語音輸入",

--- a/src/views/FeatureGuideView.vue
+++ b/src/views/FeatureGuideView.vue
@@ -8,12 +8,34 @@ import {
   Sparkles,
   BookOpen,
   History,
+  Rocket,
 } from "lucide-vue-next";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { useI18n } from "vue-i18n";
-import { markRaw } from "vue";
+import { computed, markRaw } from "vue";
 
-const { t } = useI18n();
+declare const __APP_VERSION__: string;
+const appVersion = __APP_VERSION__;
+
+const { t, tm } = useI18n();
+
+// 重用既有的五語系「升級摘要」(mainApp.upgradeNotice) 呈現當下版本更新亮點。
+// 直接萃取實際存在的 itemN key、依數字排序後 render，避免 key 不連續造成漏 item。
+const whatsNewItems = computed<string[]>(() => {
+  const notice = tm("mainApp.upgradeNotice");
+  if (typeof notice !== "object" || notice === null || Array.isArray(notice)) {
+    return [];
+  }
+  return Object.keys(notice as Record<string, unknown>)
+    .map((key) => {
+      const match = /^item([1-9]\d*)$/.exec(key);
+      return match ? { key, order: Number(match[1]) } : null;
+    })
+    .filter((entry): entry is { key: string; order: number } => entry !== null)
+    .sort((a, b) => a.order - b.order)
+    .map((entry) => t(`mainApp.upgradeNotice.${entry.key}`))
+    .filter((text) => text.length > 0);
+});
 
 const featureList = [
   { key: "voiceInput", icon: markRaw(Mic), hasSteps: true },
@@ -29,6 +51,24 @@ const featureList = [
 
 <template>
   <div class="p-6 space-y-4 text-foreground">
+    <Card v-if="whatsNewItems.length" data-testid="whats-new">
+      <CardHeader class="border-b border-border py-3">
+        <CardTitle class="text-base flex items-center gap-2">
+          <Rocket class="size-4 text-muted-foreground" aria-hidden="true" />
+          {{ t("featureGuide.whatsNew.title", { version: appVersion }) }}
+        </CardTitle>
+      </CardHeader>
+      <CardContent class="pt-3 pb-4">
+        <ol
+          class="space-y-3 text-sm text-muted-foreground leading-relaxed list-decimal list-outside pl-5"
+        >
+          <li v-for="(item, index) in whatsNewItems" :key="index">
+            {{ item }}
+          </li>
+        </ol>
+      </CardContent>
+    </Card>
+
     <p class="text-sm text-muted-foreground">
       {{ t("featureGuide.subtitle") }}
     </p>

--- a/tests/component/FeatureGuideView.test.ts
+++ b/tests/component/FeatureGuideView.test.ts
@@ -1,0 +1,131 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createI18n } from "vue-i18n";
+import { nextTick } from "vue";
+import zhTW from "../../src/i18n/locales/zh-TW.json";
+import en from "../../src/i18n/locales/en.json";
+import FeatureGuideView from "../../src/views/FeatureGuideView.vue";
+
+type Messages = Record<string, unknown>;
+
+function createTestI18n(
+  locale = "zh-TW",
+  messages: Record<string, Messages> = { "zh-TW": zhTW, en },
+) {
+  return createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: "en",
+    messages,
+  });
+}
+
+// 以獨立於元件實作的方式（用 slice 取數字，而非同一組 regex）取出 canonical item，
+// 避免測試複製元件內潛在的萃取 bug。
+function canonicalItems(messages: Messages): string[] {
+  const mainApp = messages.mainApp as Record<string, unknown>;
+  const notice = mainApp.upgradeNotice as Record<string, string>;
+  return Object.keys(notice)
+    .filter((k) => /^item\d+$/.test(k))
+    .sort((a, b) => Number(a.slice(4)) - Number(b.slice(4)))
+    .map((k) => notice[k]);
+}
+
+describe("FeatureGuideView 更新亮點卡片", () => {
+  beforeEach(() => {
+    // vitest 未套用 vite define，須手動注入 __APP_VERSION__，否則 mount 會 ReferenceError。
+    vi.stubGlobal("__APP_VERSION__", "9.9.9");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("[P1] 更新亮點卡片應是頁面第一個元素並顯示當下版本號", () => {
+    const wrapper = mount(FeatureGuideView, {
+      global: { plugins: [createTestI18n()] },
+    });
+
+    const first = wrapper.element.firstElementChild;
+    expect(first?.getAttribute("data-testid")).toBe("whats-new");
+
+    const card = wrapper.get('[data-testid="whats-new"]');
+    expect(card.text()).toContain("9.9.9");
+  });
+
+  it("[P2] 應依序渲染 upgradeNotice 的每個 item，且不出現未翻譯的 key", () => {
+    const wrapper = mount(FeatureGuideView, {
+      global: { plugins: [createTestI18n()] },
+    });
+
+    const items = wrapper
+      .findAll('[data-testid="whats-new"] li')
+      .map((li) => li.text());
+    expect(items).toEqual(canonicalItems(zhTW));
+    expect(items.length).toBeGreaterThan(0);
+
+    const text = wrapper.text();
+    expect(text).not.toContain("mainApp.upgradeNotice");
+    expect(text).not.toContain("featureGuide.whatsNew.title");
+  });
+
+  it("[P2] 切換語系後標題與內容應更新為對應語言", async () => {
+    const i18n = createTestI18n();
+    const wrapper = mount(FeatureGuideView, {
+      global: { plugins: [i18n] },
+    });
+
+    expect(wrapper.get('[data-testid="whats-new"]').text()).toContain(
+      "本次更新重點",
+    );
+
+    i18n.global.locale.value = "en";
+    await nextTick();
+
+    const card = wrapper.get('[data-testid="whats-new"]');
+    expect(card.text()).toContain("What's new in v9.9.9");
+    const items = wrapper
+      .findAll('[data-testid="whats-new"] li')
+      .map((li) => li.text());
+    expect(items).toEqual(canonicalItems(en));
+  });
+
+  it("[P2] itemN key 非連續且亂序時應依數字順序渲染", () => {
+    const messages = structuredClone(zhTW) as Messages;
+    const mainApp = messages.mainApp as Record<string, unknown>;
+    const notice = mainApp.upgradeNotice as Record<string, unknown>;
+    for (const k of Object.keys(notice)) {
+      if (/^item\d+$/.test(k)) delete notice[k];
+    }
+    // 刻意以非數字順序、且非連續（缺 item3..item9）插入，確保確實測到元件的數字排序。
+    notice.item10 = "第十項";
+    notice.item2 = "第二項";
+    notice.item1 = "第一項";
+
+    const wrapper = mount(FeatureGuideView, {
+      global: {
+        plugins: [createTestI18n("zh-TW", { "zh-TW": messages, en })],
+      },
+    });
+
+    const items = wrapper
+      .findAll('[data-testid="whats-new"] li')
+      .map((li) => li.text());
+    expect(items).toEqual(["第一項", "第二項", "第十項"]);
+  });
+
+  it("[P3] upgradeNotice 無任何 item 時應隱藏卡片", () => {
+    const noItems = structuredClone(zhTW) as Messages;
+    const mainApp = noItems.mainApp as Record<string, unknown>;
+    const notice = mainApp.upgradeNotice as Record<string, unknown>;
+    for (const k of Object.keys(notice)) {
+      if (/^item\d+$/.test(k)) delete notice[k];
+    }
+
+    const wrapper = mount(FeatureGuideView, {
+      global: { plugins: [createTestI18n("zh-TW", { "zh-TW": noItems, en })] },
+    });
+
+    expect(wrapper.find('[data-testid="whats-new"]').exists()).toBe(false);
+  });
+});

--- a/tests/unit/i18n-settings.test.ts
+++ b/tests/unit/i18n-settings.test.ts
@@ -419,5 +419,38 @@ describe("i18n 設定功能", () => {
         ).toHaveLength(0);
       }
     });
+
+    it("[P1] featureGuide.whatsNew.title 在 5 語系皆含剛好一個 {version} 佔位符", async () => {
+      const zhTW = await import("../../src/i18n/locales/zh-TW.json");
+      const en = await import("../../src/i18n/locales/en.json");
+      const ja = await import("../../src/i18n/locales/ja.json");
+      const zhCN = await import("../../src/i18n/locales/zh-CN.json");
+      const ko = await import("../../src/i18n/locales/ko.json");
+
+      const localeMap: Record<string, Record<string, unknown>> = {
+        "zh-TW": zhTW.default,
+        en: en.default,
+        ja: ja.default,
+        "zh-CN": zhCN.default,
+        ko: ko.default,
+      };
+
+      for (const [locale, messages] of Object.entries(localeMap)) {
+        const featureGuide = messages.featureGuide as Record<string, unknown>;
+        const whatsNew = featureGuide?.whatsNew as
+          | Record<string, unknown>
+          | undefined;
+        const title = whatsNew?.title;
+        expect(
+          typeof title,
+          `${locale} 缺少 featureGuide.whatsNew.title`,
+        ).toBe("string");
+        const matches = (title as string).match(/\{version\}/g) ?? [];
+        expect(
+          matches.length,
+          `${locale} 的 whatsNew.title 應含剛好一個 {version}`,
+        ).toBe(1);
+      }
+    });
   });
 });


### PR DESCRIPTION
## 摘要

在「功能介紹」頁（`FeatureGuideView.vue`，`/guide`）**最上面**新增「本次更新內容（v{version}）」卡片，重用既有五語系升級摘要 `mainApp.upgradeNotice`，讓使用者一進功能介紹頁即可看到**當下安裝版本**的重點更新。

## 變更內容

- **`src/views/FeatureGuideView.vue`**：新增 whats-new 卡片與 `whatsNewItems` computed（動態萃取 `itemN` key、依數字排序、非連續容錯；無有效 item 時以 `v-if` 隱藏卡片）。沿用既有 Card 樣式與語意色彩，標題 icon 用 lucide `Rocket`（`aria-hidden`），版本號取自 `__APP_VERSION__`。
- **i18n（5 語系）**：新增 `featureGuide.whatsNew.title`（含 `{version}` 插值），`zh-TW` / `zh-CN` / `en` / `ja` / `ko` 同步。
- **`.claude/skills/sayit-release/SKILL.md`**：修正 `mainView`→`mainApp` namespace 誤植；並註記 `/guide` 為 `upgradeNotice` 的新 consumer，提醒每次發版須同步替換五語系內容。
- **測試**：新增 `tests/component/FeatureGuideView.test.ts`（含亂序 / 非連續 `itemN` 排序案例）；擴充 `tests/unit/i18n-settings.test.ts` 驗證 5 語系 title 各含剛好一個 `{version}` 佔位符。

## 設計決策

- **內容來源**：重用既有五語系 `upgradeNotice`（非完整 CHANGELOG）——五語系一致、與發版流程自動同步、實作風險最低。
- **不加**外部連結、**不加**重量級版本綁定 metadata（避免第二個手動維護的漂移來源）。
- 卡片維持**無條件顯示**（可回訪的版本摘要，標題已標版本號，數月後仍準確）。
- 版本-亮點同步靠既有發版流程（skill 步驟必做同步 `upgradeNotice`）；本 PR 於 SKILL.md 補上 `/guide` consumer 說明以防未來漏更新。