### PR TITLE
fix(hud): fix mixed-DPI positioning and add native visibility recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ CI（`.github/workflows/ci.yml`）：`vue-tsc --noEmit` → `eslint src` → `pn
 |---------|-----------|-----------|------|------|
 | `request_app_restart` | `lib.rs` | main-window.ts | — | `()` |
 | `update_hotkey_config` | `lib.rs` | useSettingsStore | `trigger_key: TriggerKey, trigger_mode: TriggerMode` | `Result<(), String>` |
-| `get_hud_target_position` | `lib.rs` | — | `app: AppHandle` | `Result<HudTargetPosition, String>` |
+| `get_hud_target_position` | `lib.rs` | useVoiceFlowStore | `app: AppHandle` | `Result<HudTargetPosition, String>`（含 `space: "physical"\|"logical"`，Windows 回 physical 以避開 tao 跨 DPI 錯位） |
+| `ensure_hud_visible` | `lib.rs` | useVoiceFlowStore（showHud 後） | `app: AppHandle` | `()`（Windows：記錄可見性快照 + 安全恢復：最小化還原、重宣告 topmost；非 Windows：no-op） |
 | `set_file_logging_enabled` | `plugins/logging.rs` | useSettingsStore, logger.ts | `enabled: bool` | `()` |
 | `open_log_folder` | `plugins/logging.rs` | logger.ts（SettingsView） | — | `Result<(), String>` |
 | `cleanup_old_logs` | `plugins/logging.rs` | main-window.ts | `days: u32, app: AppHandle` | `Result<Vec<String>, String>` |

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ windows = { version = "0.61", features = [
     "Win32_System_Threading",
     "Win32_UI_Accessibility",
     "Win32_System_Registry",
+    "Win32_Graphics_Dwm",
 ] }
 
 [profile.dev]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,7 +60,7 @@ fn configure_windows_topmost_window(window: &tauri::WebviewWindow) {
             // 讀取現有 extended style，加入 TOOLWINDOW + NOACTIVATE
             let ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
             let new_ex_style = WINDOW_EX_STYLE(ex_style as u32)
-                | WS_EX_TOOLWINDOW    // 不出現在 Alt+Tab / taskbar，出現在所有虛擬桌面
+                | WS_EX_TOOLWINDOW    // 不出現在 Alt+Tab / taskbar（與虛擬桌面顯示無關）
                 | WS_EX_NOACTIVATE; // 點擊不搶焦點
             SetWindowLongPtrW(hwnd, GWL_EXSTYLE, new_ex_style.0 as isize);
 
@@ -215,6 +215,9 @@ pub struct HudTargetPosition {
     x: f64,
     y: f64,
     monitor_key: String,
+    /// 座標空間標記：Windows 回傳 "physical"（前端用 PhysicalPosition，DPI-safe），
+    /// 其餘平台回傳 "logical"（前端用 LogicalPosition，維持既有行為）。
+    space: String,
 }
 
 /// 抽象化的螢幕資訊，用於 `find_monitor_for_cursor()` 純函式測試
@@ -353,26 +356,152 @@ fn get_hud_target_position(app: tauri::AppHandle) -> Result<HudTargetPosition, S
     let matched_monitor = &monitor_infos[idx];
     let sf = matched_monitor.scale_factor;
 
-    // 還原螢幕的 logical origin（macOS: physical / sf = NSScreen points）
-    let monitor_logical_x = matched_monitor.position_x as f64 / sf;
-    let monitor_logical_y = matched_monitor.position_y as f64 / sf;
-
-    // 計算 HUD 在目標螢幕上的 logical 置中偏移
-    let centered_x_logical =
-        calculate_centered_window_x_logical(matched_monitor.width, sf, HUD_WINDOW_WIDTH_LOGICAL);
-
-    let hud_x = monitor_logical_x + centered_x_logical;
-    let hud_y = monitor_logical_y;
     let monitor_key = format!(
         "{},{}",
         matched_monitor.position_x, matched_monitor.position_y
     );
 
-    Ok(HudTargetPosition {
-        x: hud_x,
-        y: hud_y,
-        monitor_key,
-    })
+    // 依平台選座標空間，避免 tao 在混合 DPI 下錯位：
+    // - Windows：回傳「絕對 physical 座標」，前端以 PhysicalPosition 定位。dpi 的
+    //   PhysicalPosition → physical 轉換是 identity（不乘 scale factor），可避開 tao 對
+    //   LogicalPosition 以「視窗當前螢幕 SF」轉換，在多螢幕不同縮放時把 HUD 移到錯誤位置/離螢幕。
+    // - macOS（及其他）：維持既有 logical 座標路徑（NSScreen points），前端用 LogicalPosition。
+    let position = {
+        #[cfg(target_os = "windows")]
+        {
+            let centered_x_physical =
+                calculate_centered_window_x(matched_monitor.width, sf, HUD_WINDOW_WIDTH_LOGICAL);
+            HudTargetPosition {
+                x: matched_monitor.position_x as f64 + centered_x_physical as f64,
+                y: matched_monitor.position_y as f64,
+                monitor_key,
+                space: "physical".to_string(),
+            }
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            // 還原螢幕的 logical origin（macOS: physical / sf = NSScreen points）
+            let monitor_logical_x = matched_monitor.position_x as f64 / sf;
+            let monitor_logical_y = matched_monitor.position_y as f64 / sf;
+            let centered_x_logical = calculate_centered_window_x_logical(
+                matched_monitor.width,
+                sf,
+                HUD_WINDOW_WIDTH_LOGICAL,
+            );
+            HudTargetPosition {
+                x: monitor_logical_x + centered_x_logical,
+                y: monitor_logical_y,
+                monitor_key,
+                space: "logical".to_string(),
+            }
+        }
+    };
+
+    Ok(position)
+}
+
+/// 診斷並嘗試恢復 HUD 視窗的原生可見性狀態（RC2）。
+///
+/// 於前端每次 `showHud()`（`window.show()` 之後）呼叫。設計原則（依 RubberDuck）：
+/// **先記錄快照、再只針對已證實狀態做安全恢復；不做 blanket hide/show**（會閃爍、與 250ms
+/// 輪詢/ fire-and-forget showHud 疊成迴圈，且對 cloak/最小化未必有效）。cloak 僅記錄不強解。
+#[command]
+fn ensure_hud_visible(app: tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        #[cfg(target_os = "windows")]
+        ensure_hud_visible_windows(&window);
+        #[cfg(not(target_os = "windows"))]
+        let _ = window;
+    }
+}
+
+/// Windows：記錄 HUD 視窗原生可見性快照（供單螢幕/混合 DPI 現場 log 判定 RC2），
+/// 並做安全恢復：最小化 → 不搶焦點還原；重新宣告 topmost（保留 `SWP_NOACTIVATE`）。
+#[cfg(target_os = "windows")]
+fn ensure_hud_visible_windows(window: &tauri::WebviewWindow) {
+    use std::ffi::c_void;
+    use windows::Win32::Foundation::RECT;
+    use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_CLOAKED};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetForegroundWindow, GetWindowLongPtrW, GetWindowRect, IsIconic, IsWindowVisible,
+        SetWindowPos, ShowWindow, GWL_EXSTYLE, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE,
+        SWP_NOSIZE, SW_SHOWNOACTIVATE, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST,
+    };
+
+    let hwnd = match window.hwnd() {
+        Ok(h) => h,
+        Err(e) => {
+            log::error!("[hud-visibility] Failed to get HWND: {e}");
+            return;
+        }
+    };
+
+    unsafe {
+        let visible = IsWindowVisible(hwnd).as_bool();
+        let iconic = IsIconic(hwnd).as_bool();
+
+        let mut rect = RECT::default();
+        let _ = GetWindowRect(hwnd, &mut rect);
+
+        // DWMWA_CLOAKED：非 0 代表視窗被 DWM/Shell 隱藏（含虛擬桌面切走），
+        // bits: 0x1=APP, 0x2=SHELL(含虛擬桌面), 0x4=INHERITED。
+        let mut cloaked: u32 = 0;
+        let _ = DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_CLOAKED,
+            &mut cloaked as *mut u32 as *mut c_void,
+            std::mem::size_of::<u32>() as u32,
+        );
+
+        let ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE) as u32;
+        let is_topmost = ex_style & WS_EX_TOPMOST.0 != 0;
+        let has_toolwindow = ex_style & WS_EX_TOOLWINDOW.0 != 0;
+        let has_noactivate = ex_style & WS_EX_NOACTIVATE.0 != 0;
+        let foreground = GetForegroundWindow();
+
+        log::info!(
+            "[hud-visibility] visible={visible} iconic={iconic} cloaked=0x{cloaked:x} \
+             topmost={is_topmost} toolwindow={has_toolwindow} noactivate={has_noactivate} \
+             exstyle=0x{ex_style:x} rect=({},{},{},{}) foreground={foreground:?}",
+            rect.left,
+            rect.top,
+            rect.right,
+            rect.bottom,
+        );
+
+        // cloak/虛擬桌面：只能診斷。Shell cloak（含虛擬桌面切走）無法在此強制解除，
+        // 屬已知限制；待現場 log 佐證後再評估 IVirtualDesktopManager 等較重方案。
+        if cloaked != 0 {
+            log::warn!(
+                "[hud-visibility] DWM-cloaked (0x{cloaked:x})；shell/虛擬桌面 cloak 無法在此強制解除（已知限制，僅診斷）"
+            );
+        }
+        // 安全恢復（僅針對已證實狀態；不做 blanket hide/show）：
+        // 原生 visible=false 或最小化 → SW_SHOWNOACTIVATE（顯示/還原但不搶焦點），修 RC2 async-show latch
+        if !visible || iconic {
+            log::warn!(
+                "[hud-visibility] not-visible/minimized (visible={visible} iconic={iconic}) → SW_SHOWNOACTIVATE"
+            );
+            let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+            let visible_after = IsWindowVisible(hwnd).as_bool();
+            let iconic_after = IsIconic(hwnd).as_bool();
+            log::info!(
+                "[hud-visibility] after SW_SHOWNOACTIVATE: visible={visible_after} iconic={iconic_after}"
+            );
+        }
+        // 重新宣告 topmost（保留 NOACTIVATE：HUD 不可搶走貼上目標焦點）
+        if let Err(e) = SetWindowPos(
+            hwnd,
+            Some(HWND_TOPMOST),
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+        ) {
+            log::warn!("[hud-visibility] SetWindowPos(HWND_TOPMOST) failed: {e}");
+        }
+    }
 }
 
 fn show_main_window(app: &AppHandle) {
@@ -487,6 +616,7 @@ pub fn run() {
             plugins::logging::cleanup_old_logs,
             update_hotkey_config,
             get_hud_target_position,
+            ensure_hud_visible,
             get_os_theme,
             plugins::audio_control::mute_system_audio,
             plugins::audio_control::restore_system_audio,

--- a/src/stores/useVoiceFlowStore.ts
+++ b/src/stores/useVoiceFlowStore.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { LogicalPosition } from "@tauri-apps/api/dpi";
+import { LogicalPosition, PhysicalPosition } from "@tauri-apps/api/dpi";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { Window, getCurrentWindow } from "@tauri-apps/api/window";
 import { defineStore } from "pinia";
@@ -89,6 +89,8 @@ function t(key: string, params?: Record<string, unknown>): string {
 }
 
 const MONITOR_POLL_INTERVAL_MS = 250;
+// reposition 不得阻擋 show：逾時仍先 show，避免偶發卡住讓 HUD 永不出現
+const REPOSITION_SHOW_TIMEOUT_MS = 500;
 
 export const useVoiceFlowStore = defineStore("voice-flow", () => {
   const status = ref<HudStatus>("idle");
@@ -102,7 +104,12 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
   let collapseHideTimer: ReturnType<typeof setTimeout> | null = null;
   const COLLAPSE_HIDE_DELAY_MS = 400;
   const lastWasModified = ref<boolean | null>(null);
-  let monitorPollTimer: ReturnType<typeof setInterval> | null = null;
+  let monitorPollTimer: ReturnType<typeof setTimeout> | null = null;
+  // 輪詢世代：每次 start/stop 遞增；in-flight 的 scheduleNext 以捕獲的世代比對，
+  // 避免舊 loop 在 restart 後「復活」與新 loop 並存（各自 setTimeout、互相覆寫 handle）。
+  let monitorPollGeneration = 0;
+  // reposition single-flight：同一時間只有一個進行中的操作，避免掛死時累積 native invoke。
+  let inFlightReposition: Promise<void> | null = null;
   let delayedMuteTimer: ReturnType<typeof setTimeout> | null = null;
   let learnedHideTimer: ReturnType<typeof setTimeout> | null = null;
   const LEARNED_NOTIFICATION_TOTAL_DURATION_MS = 2800; // 2000 display + 400 collapse + 400 buffer
@@ -153,7 +160,9 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
   const MODE_SWITCH_LABEL_DURATION_MS = 3000;
 
   let lastMonitorKey = "";
-  let isRepositioning = false;
+  // reposition 世代編號：以遞增序號取代單一 boolean，過期回呼直接失效，避免
+  // 「永不 settle 的 async 操作」把重定位鎖死（並防止舊回呼寫入過期位置）。
+  let repositionSeq = 0;
 
   function getAppWindow() {
     if (!cachedAppWindow) cachedAppWindow = getCurrentWindow();
@@ -208,49 +217,88 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
     void emitEvent(VOICE_FLOW_STATE_CHANGED, payload);
   }
 
-  async function repositionHudToCurrentMonitor() {
-    if (isRepositioning) return;
-    isRepositioning = true;
-    try {
-      const position = await invoke<HudTargetPosition>(
-        "get_hud_target_position",
-      );
-      if (position.monitorKey !== lastMonitorKey) {
-        lastMonitorKey = position.monitorKey;
-        await getAppWindow().setPosition(
-          new LogicalPosition(position.x, position.y),
+  function repositionHudToCurrentMonitor(): Promise<void> {
+    // single-flight：進行中就回傳同一個 promise，不重複發 invoke（掛死時不累積 native request，
+    // 且 showHudOnce 與輪詢共用同一操作）。逾時保護由 showHudOnce 的 Promise.race 負責。
+    if (inFlightReposition) return inFlightReposition;
+    const seq = ++repositionSeq;
+    inFlightReposition = (async () => {
+      try {
+        const position = await invoke<HudTargetPosition>(
+          "get_hud_target_position",
         );
+        // 過期回呼（已有更新的 reposition 發起 / polling 已停止）直接失效
+        if (seq !== repositionSeq) return;
+        // 去重 key 納入 space/x/y：同一螢幕的 DPI/解析度變更（座標改變）也會觸發重定位
+        const key = `${position.monitorKey}|${position.space}|${position.x}|${position.y}`;
+        if (key !== lastMonitorKey) {
+          // Windows 回傳 physical 座標（DPI-safe）；macOS 回傳 logical。依 space 選對應型別，
+          // 避免 tao 在混合 DPI 下用「視窗當前螢幕 SF」轉換 LogicalPosition 造成錯位。
+          const target =
+            position.space === "physical"
+              ? new PhysicalPosition(position.x, position.y)
+              : new LogicalPosition(position.x, position.y);
+          await getAppWindow().setPosition(target);
+          // 僅在成功定位且仍為最新世代後才更新 last-known-good，避免失敗仍跳過後續重試
+          if (seq === repositionSeq) lastMonitorKey = key;
+        }
+      } catch {
+        // 螢幕監控重定位失敗為低優先級，不 log 避免洗版（保留上次成功的 key 為 last-known-good）
+      } finally {
+        inFlightReposition = null;
       }
-    } catch {
-      // 螢幕監控重定位失敗為低優先級，不 log 避免洗版
-    } finally {
-      isRepositioning = false;
-    }
+    })();
+    return inFlightReposition;
   }
 
   function startMonitorPolling() {
     stopMonitorPolling();
-    monitorPollTimer = setInterval(() => {
-      void repositionHudToCurrentMonitor();
-    }, MONITOR_POLL_INTERVAL_MS);
+    // 自排程迴圈 + 世代 token：下一輪只在「本輪 reposition 真正 settle 後」才排（single-flight，
+    // 杜絕重疊/累積）；並以捕獲的世代比對，避免舊 loop 的 finally 回呼在 restart 後復活。
+    const generation = ++monitorPollGeneration;
+    const scheduleNext = () => {
+      if (generation !== monitorPollGeneration) return;
+      monitorPollTimer = setTimeout(() => {
+        if (generation !== monitorPollGeneration) return;
+        void repositionHudToCurrentMonitor().finally(scheduleNext);
+      }, MONITOR_POLL_INTERVAL_MS);
+    };
+    scheduleNext();
   }
 
   function stopMonitorPolling() {
+    // 遞增世代 → 使所有進行中 loop 的 scheduleNext 失效（含尚未 settle 的 reposition.finally）
+    monitorPollGeneration++;
     if (monitorPollTimer) {
-      clearInterval(monitorPollTimer);
+      clearTimeout(monitorPollTimer);
       monitorPollTimer = null;
     }
     lastMonitorKey = "";
-    isRepositioning = false;
+    // 使進行中的 reposition 回呼失效（避免停止後仍寫入過期位置）
+    repositionSeq++;
+  }
+
+  // 顯示 HUD 一次（定位 → show → 忽略游標 → ensure），不啟動輪詢。
+  // 供主流程與 learned-notification 共用，確保兩者都套用 RC1 定位與 RC2 ensure。
+  async function showHudOnce() {
+    const window = getAppWindow();
+    lastMonitorKey = "";
+    // reposition 不得阻擋 show：逾時則先 show（RC1 修法後座標已正確；避免偶發卡住讓 HUD 永不出現）
+    await Promise.race([
+      repositionHudToCurrentMonitor(),
+      new Promise<void>((resolve) =>
+        setTimeout(resolve, REPOSITION_SHOW_TIMEOUT_MS),
+      ),
+    ]);
+    await window.show();
+    await window.setIgnoreCursorEvents(true);
+    // RC2：診斷原生可見性 + 安全恢復（visible=false/最小化→SW_SHOWNOACTIVATE、重宣告 topmost）；不做 blanket hide/show
+    void invoke("ensure_hud_visible").catch(() => {});
   }
 
   async function showHud() {
     clearLearnedHideTimer();
-    const window = getAppWindow();
-    lastMonitorKey = "";
-    await repositionHudToCurrentMonitor();
-    await window.show();
-    await window.setIgnoreCursorEvents(true);
+    await showHudOnce();
     startMonitorPolling();
   }
 
@@ -738,11 +786,10 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
                         "useVoiceFlowStore: VOCABULARY_LEARNED emitted successfully",
                       );
 
-                      // HUD 視窗在 idle 後已被 hideHud() 隱藏，需重新顯示才看得到通知
+                      // HUD 視窗在 idle 後已被 hideHud() 隱藏，需重新顯示才看得到通知。
+                      // 與主流程一致：定位（RC1）+ show + ensure（RC2）；不啟動 polling（learned timer 負責隱藏）
                       clearLearnedHideTimer();
-                      const appWindow = getAppWindow();
-                      await appWindow.show();
-                      await appWindow.setIgnoreCursorEvents(true);
+                      await showHudOnce();
                       learnedHideTimer = setTimeout(() => {
                         learnedHideTimer = null;
                         if (status.value === "idle") {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,4 +19,6 @@ export interface HudTargetPosition {
   x: number;
   y: number;
   monitorKey: string;
+  /** 座標空間：Windows 為 "physical"（用 PhysicalPosition，DPI-safe），其餘為 "logical"。 */
+  space: "physical" | "logical";
 }

--- a/tests/unit/use-voice-flow-store.test.ts
+++ b/tests/unit/use-voice-flow-store.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 // "errors.apiKeyMissing" removed — now uses i18n key
 import { HOTKEY_ERROR_CODES } from "@/types/events";
+import { PhysicalPosition } from "@tauri-apps/api/dpi";
 
 const {
   mockListen,
@@ -9,6 +10,7 @@ const {
   mockInvoke,
   mockEnhanceText,
   mockGetCurrentWindow,
+  mockSetPosition,
   mockWebviewWindowGetByLabel,
   mockMainWindowShow,
   mockMainWindowSetFocus,
@@ -35,6 +37,7 @@ const {
   );
   const mockMainWindowShow = vi.fn().mockResolvedValue(undefined);
   const mockMainWindowSetFocus = vi.fn().mockResolvedValue(undefined);
+  const mockSetPosition = vi.fn().mockResolvedValue(undefined);
   const mockWebviewWindowGetByLabel = vi.fn(async (label: string) => {
     if (label !== "main-window") return null;
     return {
@@ -75,9 +78,11 @@ const {
       show: vi.fn().mockResolvedValue(undefined),
       hide: vi.fn().mockResolvedValue(undefined),
       setIgnoreCursorEvents: vi.fn().mockResolvedValue(undefined),
+      setPosition: mockSetPosition,
     })),
     mockMainWindowShow,
     mockMainWindowSetFocus,
+    mockSetPosition,
     mockWebviewWindowGetByLabel,
     mockLoadSettings: vi.fn().mockResolvedValue(undefined),
     mockSettingsState: {
@@ -373,6 +378,7 @@ describe("useVoiceFlowStore", () => {
       .mockResolvedValue(undefined);
     mockAddApiUsage.mockClear().mockResolvedValue(undefined);
     mockGetCurrentWindow.mockClear();
+    mockSetPosition.mockClear();
     mockWebviewWindowGetByLabel.mockClear();
     mockMainWindowShow.mockClear().mockResolvedValue(undefined);
     mockMainWindowSetFocus.mockClear().mockResolvedValue(undefined);
@@ -452,6 +458,28 @@ describe("useVoiceFlowStore", () => {
       status: "recording",
       message: "voiceFlow.recording",
     });
+  });
+
+  it("[P1] Windows physical space 應以 PhysicalPosition 定位 HUD（DPI-safe，RC1）", async () => {
+    const baseHandler = createMockInvokeHandler();
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "get_hud_target_position") {
+        return { monitorKey: "win-mixed-dpi", x: 1280, y: 0, space: "physical" };
+      }
+      return baseHandler(cmd);
+    });
+
+    const store = useVoiceFlowStore();
+    await store.initialize();
+
+    triggerHotkeyEvent("hotkey:pressed");
+    await vi.waitFor(() => {
+      expect(mockSetPosition).toHaveBeenCalled();
+    });
+
+    const lastArg = mockSetPosition.mock.calls.at(-1)?.[0];
+    expect(lastArg).toBeInstanceOf(PhysicalPosition);
+    expect(lastArg).toMatchObject({ x: 1280, y: 0 });
   });
 
   it("[P0] HOTKEY_RELEASED 應完成 錄音→轉錄→貼上→success 並廣播事件", async () => {


### PR DESCRIPTION
## 問題
Windows 上 HUD（notch 浮窗）在 App 開著一段時間後就不再顯示，但錄音→轉錄→貼上功能完全正常。多螢幕混合 DPI 機器「常常」發生；單螢幕機器「偶爾」發生；兩者皆為「一旦消失就持續、要重啟 App 才恢復」。

關鍵：HUD 的顯示與語音功能**完全解耦**（語音全走後端 `invoke`，`showHud` 為 fire-and-forget），所以 HUD 被移到螢幕外／原生不可見時功能照常。收斂為兩個並存根因。

## RC1 — 跨 DPI 座標錯置（多螢幕混合 DPI）
`get_hud_target_position` 回傳 logical 座標，前端用 `LogicalPosition`；tao 在 Windows 以**視窗「當前」螢幕 scale factor** 轉回實體像素。當游標移到不同縮放的螢幕時，`當前 SF ≠ 目標 SF` → HUD 被放到錯誤位置／螢幕外。

**修法**：Windows 改回傳**絕對 physical 座標** + `space: "physical"`，前端改用 `PhysicalPosition`（`dpi` crate 的 physical→physical 為 identity，不受 scale factor 影響，DPI-safe）。macOS 維持既有 logical 路徑不變。

## RC2 — 與螢幕數無關的持續性原生不可見狀態（單螢幕也會）
新增 `ensure_hud_visible` 指令，每次 show 後：
- **診斷 log**：`IsWindowVisible` / `IsIconic` / `DWMWA_CLOAKED` / topmost / exstyle / rect / foreground（供現場定位虛擬桌面 cloak／最小化／位置等）。
- **安全恢復**（僅針對已證實狀態，不做 blanket hide/show）：`!visible || iconic → SW_SHOWNOACTIVATE`（不搶焦點）、重新宣告 `HWND_TOPMOST`（`SWP_NOACTIVATE`）。
- shell cloak／虛擬桌面標為**已知限制（僅診斷）**，後續視 log 再評估 `IVirtualDesktopManager` 等較重方案。

## 非同步硬化（`useVoiceFlowStore`）
- reposition 改 **single-flight coalescing**：進行中的操作只有一個，掛死時不累積 native invoke。
- 輪詢改**自排程迴圈 + 世代 token**：杜絕重疊/累積，並避免舊 loop 在 restart 後復活與新 loop 並存。
- `showHud` 以 500ms race 確保 reposition 不阻擋 show；抽出 `showHudOnce()` 讓 learned-notification 也套用定位與 ensure。

## 變更檔案
- `src-tauri/src/lib.rs`：`HudTargetPosition` 加 `space`；`get_hud_target_position` 依平台分支；新增 `ensure_hud_visible`（Windows 診斷+恢復）並註冊。
- `src-tauri/Cargo.toml`：新增 `Win32_Graphics_Dwm` feature（`DWMWA_CLOAKED`）。
- `src/stores/useVoiceFlowStore.ts`、`src/types/index.ts`：`PhysicalPosition` 依 `space` 選型、single-flight、世代 token、`showHudOnce`。
- `tests/unit/use-voice-flow-store.test.ts`：新增 RC1 physical→`PhysicalPosition` 回歸測試。
- `AGENTS.md`：更新 IPC 契約表。

## 重現/驗證方式
RC1 可秒級重現：HUD 停在高 DPI 螢幕 → 游標移到低 DPI 螢幕 → 按熱鍵錄音（修前錯位/消失、修後正常）。RC2 需在單螢幕機器掛機至復現，讀 `[hud-visibility]` log 判定。

> 平台限制：Windows-only 原生程式碼由 CI（Windows matrix）+ 實機驗證；macOS 路徑未動。

## Follow-up（非阻擋）
- fake-timer 回歸測試（stop→restart／掛死路徑）。
- `space` 可改為 enum（目前 stringly-typed，兩端已對齊）。