### PR TITLE
feat(tray): Windows 系統匣圖示雙擊開啟 Dashboard

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{
     command,
     menu::{Menu, MenuItem},
-    tray::TrayIconBuilder,
+    tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
     AppHandle, Manager, Runtime,
 };
 
@@ -506,6 +506,7 @@ fn ensure_hud_visible_windows(window: &tauri::WebviewWindow) {
 
 fn show_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main-window") {
+        let _ = window.unminimize();
         let _ = window.show();
         let _ = window.set_focus();
     }
@@ -731,7 +732,9 @@ pub fn run() {
                 ))?)
                 .icon_as_template(true)
                 .menu(&menu)
-                .show_menu_on_left_click(true)
+                // Windows：關閉左鍵選單，改由右鍵顯示選單、左鍵雙擊開啟 Dashboard；
+                // macOS/Linux：維持左鍵單擊顯示選單（menu bar 慣例）。
+                .show_menu_on_left_click(!cfg!(target_os = "windows"))
                 .tooltip("SayIt")
                 .on_menu_event(|app, event| match event.id.as_ref() {
                     "open-dashboard" => {
@@ -741,6 +744,16 @@ pub fn run() {
                         app.exit(0);
                     }
                     _ => {}
+                })
+                .on_tray_icon_event(|tray, event| {
+                    // DoubleClick 為 Tauri 定義的 Windows Only 事件，macOS/Linux 不會觸發。
+                    if let TrayIconEvent::DoubleClick {
+                        button: MouseButton::Left,
+                        ..
+                    } = event
+                    {
+                        show_main_window(tray.app_handle());
+                    }
                 })
                 .build(app)?;
 


### PR DESCRIPTION
## 摘要
Windows 系統匣（tray）圖示原本必須「右鍵 → 開啟 Dashboard」才能開啟主視窗，左鍵雙擊沒有反應。本 PR 讓**左鍵雙擊 tray 圖示即開啟 Dashboard（`main-window`）**。

## 變更（單一檔案 `src-tauri/src/lib.rs`）
- 為 `TrayIconBuilder` 註冊 `on_tray_icon_event`，攔截 `TrayIconEvent::DoubleClick`（左鍵）→ 開啟 Dashboard。
- `.show_menu_on_left_click(true)` → `.show_menu_on_left_click(!cfg!(target_os = "windows"))`：Windows 關閉左鍵選單（避免第一擊彈選單干擾雙擊偵測），macOS/Linux 維持左鍵單擊顯示選單（menu bar 慣例）。
- `show_main_window()` 加入 `unminimize()`，讓被最小化的視窗也能還原到前景。

## 行為對照
| 操作 | Windows | macOS |
|---|---|---|
| 左鍵雙擊 | 開啟 / 還原 / focus Dashboard ✅（新增） | 不觸發（此事件為 Windows Only） |
| 右鍵 | 顯示選單（不變） | — |
| 左鍵單擊 | 無反應（原為顯示選單，刻意取捨） | 顯示選單（不變） |

## 技術重點
- `TrayIconEvent::DoubleClick` 為 Tauri 定義的 **Windows Only** 事件，跨平台 closure 天然只在 Windows 生效，**macOS 行為不變**。
- `show_main_window` 為共用函式，`unminimize()` 讓 tray 選單、macOS `Reopen`、single-instance callback 等路徑一併能還原最小化視窗（正向改善）。
- 未新增/變更任何 Tauri Command 或 Event，**無 IPC 契約變動**。

## 驗收（手動，Windows 實機建議）
- [ ] 預設隱藏後雙擊開啟
- [ ] 關閉成 hidden 後再次雙擊可開啟
- [ ] 最小化後雙擊還原並取得焦點
- [ ] 背景視窗雙擊帶到前景
- [ ] 左鍵單擊無選單、右鍵選單正常