### PR TITLE
feat(dictionary): 合併字典為單一可排序表格並新增來源欄

### DIFF
--- a/src/composables/useTableSort.ts
+++ b/src/composables/useTableSort.ts
@@ -1,0 +1,74 @@
+import { computed, ref, type Ref } from "vue";
+
+export type SortDirection = "asc" | "desc";
+
+export interface SortColumn<T, K extends string> {
+  key: K;
+  /** 升冪語意的主鍵比較（回傳 <0 表示 a 應排在 b 前） */
+  compare: (a: T, b: T) => number;
+  /** 首次點擊此欄時採用的方向，未指定則為 "asc" */
+  defaultDirection?: SortDirection;
+}
+
+export interface SortState<K extends string> {
+  key: K;
+  direction: SortDirection;
+}
+
+export interface UseTableSortReturn<T, K extends string> {
+  sortState: Ref<SortState<K>>;
+  toggleSort: (key: K) => void;
+  sortedList: Ref<T[]>;
+}
+
+/**
+ * 通用表格排序：對來源清單就地（複本）排序，並管理二態排序狀態。
+ *
+ * 關鍵設計：
+ * - 方向 factor 只作用於「主鍵比較」；`tieBreak` 為固定次鍵，不受方向反轉影響，
+ *   確保降冪時同主鍵值的相對次序仍穩定、可預期。
+ * - `source` 以 getter 形式傳入，於 `sortedList` computed 內呼叫，
+ *   使來源清單與 comparator 內讀取的響應式值（如 i18n locale）都能被正確追蹤。
+ */
+export function useTableSort<T, K extends string>(
+  source: () => T[],
+  columns: SortColumn<T, K>[],
+  initial: SortState<K>,
+  tieBreak: (a: T, b: T) => number = () => 0,
+): UseTableSortReturn<T, K> {
+  const columnMap = new Map<K, SortColumn<T, K>>(
+    columns.map((column) => [column.key, column]),
+  );
+
+  const sortState = ref<SortState<K>>({ ...initial }) as Ref<SortState<K>>;
+
+  function toggleSort(key: K) {
+    if (sortState.value.key === key) {
+      sortState.value = {
+        key,
+        direction: sortState.value.direction === "asc" ? "desc" : "asc",
+      };
+      return;
+    }
+    sortState.value = {
+      key,
+      direction: columnMap.get(key)?.defaultDirection ?? "asc",
+    };
+  }
+
+  const sortedList = computed<T[]>(() => {
+    const { key, direction } = sortState.value;
+    const list = [...source()];
+    const column = columnMap.get(key);
+    if (!column) return list;
+
+    const factor = direction === "asc" ? 1 : -1;
+    return list.sort((a, b) => {
+      const primary = column.compare(a, b) * factor;
+      if (primary !== 0) return primary;
+      return tieBreak(a, b);
+    });
+  });
+
+  return { sortState, toggleSort, sortedList };
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -365,14 +365,14 @@
     "dateHeader": "Date Added",
     "actionHeader": "Actions",
     "loadFailed": "Failed to load term list",
-    "aiRecommended": "AI Suggested",
-    "manualAdded": "Manually Added",
+    "sourceHeader": "Source",
+    "sourceManual": "Manual",
+    "sourceAi": "AI",
     "weight": "Weight",
     "description": "Dictionary terms are provided to the AI during speech recognition to improve accuracy for proper nouns and technical terms.",
     "weightDescription": "During each speech recognition, the top {limit} terms by weight are included in the AI recognition prompt. When the AI detects you repeatedly correcting the same term, its weight increases automatically.",
     "noAiSuggestions": "No AI suggestions yet. Enable Smart Dictionary Learning to auto-learn new terms",
     "noAiSuggestionsEnabled": "Smart Dictionary Learning is on. New terms are learned automatically when you correct a transcription",
-    "aiTermCount": "{count} terms",
     "importHint": "Migrating from another tool (e.g. Typeless)? Import your wordlist (.txt/.csv/.json) from Settings → Backup & Restore."
   },
   "accessibility": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -365,14 +365,14 @@
     "dateHeader": "追加日時",
     "actionHeader": "操作",
     "loadFailed": "語彙リストの読み込みに失敗しました",
-    "aiRecommended": "AI 推奨",
-    "manualAdded": "手動追加",
+    "sourceHeader": "ソース",
+    "sourceManual": "手動",
+    "sourceAi": "AI",
     "weight": "重み",
     "description": "辞書の用語は音声認識時に AI に提供され、固有名詞や技術用語の認識精度を向上させます。",
     "weightDescription": "音声認識のたびに、重みが最も高い上位 {limit} 語が AI 認識プロンプトに含まれます。同じ修正が繰り返し検出されると、その用語の重みが自動的に増加します。",
     "noAiSuggestions": "AI 推奨の用語はまだありません。スマート辞書学習を有効にすると自動学習されます",
     "noAiSuggestionsEnabled": "スマート辞書学習は有効です。文字起こしを修正すると、新しい用語が自動的に学習されます",
-    "aiTermCount": "{count} 語",
     "importHint": "他のツール（Typeless など）から移行しますか？「設定 → バックアップと復元」から単語リスト（.txt/.csv/.json）をインポートできます。"
   },
   "accessibility": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -365,14 +365,14 @@
     "dateHeader": "추가 일시",
     "actionHeader": "작업",
     "loadFailed": "단어 목록 로드에 실패했습니다",
-    "aiRecommended": "AI 추천",
-    "manualAdded": "수동 추가",
+    "sourceHeader": "출처",
+    "sourceManual": "수동",
+    "sourceAi": "AI",
     "weight": "가중치",
     "description": "사전 용어는 음성 인식 시 AI에 제공되어 고유명사와 기술 용어의 인식 정확도를 높입니다.",
     "weightDescription": "음성 인식 시 가중치가 가장 높은 상위 {limit}개 용어가 AI 인식 프롬프트에 포함됩니다. 동일한 수정이 반복 감지되면 해당 용어의 가중치가 자동으로 증가합니다.",
     "noAiSuggestions": "아직 AI 추천 용어가 없습니다. 스마트 사전 학습을 활성화하면 자동으로 학습됩니다",
     "noAiSuggestionsEnabled": "스마트 사전 학습이 켜져 있습니다. 전사를 수정하면 새 용어가 자동으로 학습됩니다",
-    "aiTermCount": "{count}개 용어",
     "importHint": "다른 도구(예: Typeless)에서 이전하시나요? '설정 → 백업 및 복원'에서 단어 목록(.txt/.csv/.json)을 가져오세요."
   },
   "accessibility": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -365,14 +365,14 @@
     "dateHeader": "新增时间",
     "actionHeader": "操作",
     "loadFailed": "加载词汇清单失败",
-    "aiRecommended": "AI 推荐",
-    "manualAdded": "手动添加",
+    "sourceHeader": "来源",
+    "sourceManual": "手动",
+    "sourceAi": "AI 推荐",
     "weight": "权重",
     "description": "字典词汇会在语音识别时提供给 AI，提升专有名词与术语的识别准确度。",
     "weightDescription": "每次语音识别时，系统会将权重最高的前 {limit} 个词汇加入 AI 识别提示。当 AI 检测到你重复修正同一个词时，该词的权重会自动提升。",
     "noAiSuggestions": "暂无 AI 推荐词汇，启用智能字典学习后系统会自动学习",
     "noAiSuggestionsEnabled": "智能字典学习已启用，当你修正转录文字时系统会自动学习新词",
-    "aiTermCount": "{count} 个词",
     "importHint": "要从其他工具（如 Typeless）迁移吗？请到「设置 → 备份与还原」导入词表（.txt/.csv/.json）。"
   },
   "accessibility": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -365,14 +365,14 @@
     "dateHeader": "新增時間",
     "actionHeader": "操作",
     "loadFailed": "載入詞彙清單失敗",
-    "aiRecommended": "AI 推薦",
-    "manualAdded": "手動新增",
+    "sourceHeader": "來源",
+    "sourceManual": "手動",
+    "sourceAi": "AI 推薦",
     "weight": "權重",
     "description": "字典詞彙會在語音辨識時提供給 AI，提升專有名詞與術語的辨識準確度。",
     "weightDescription": "每次語音辨識時，系統會將權重最高的前 {limit} 個詞彙加入 AI 辨識提示。當 AI 偵測到你重複修正同一個詞時，該詞的權重會自動提升。",
     "noAiSuggestions": "尚無 AI 推薦詞彙，啟用智慧字典學習後系統會自動學習",
     "noAiSuggestionsEnabled": "智慧字典學習已啟用，當你修正轉錄文字時系統會自動學習新詞",
-    "aiTermCount": "{count} 個詞",
     "importHint": "要從其他工具（如 Typeless）遷移嗎？請至「設定 → 備份與還原」匯入詞表（.txt/.csv/.json）。"
   },
   "accessibility": {

--- a/src/views/DictionaryView.vue
+++ b/src/views/DictionaryView.vue
@@ -4,9 +4,19 @@ import { useVocabularyStore } from "../stores/useVocabularyStore";
 import { useSettingsStore } from "../stores/useSettingsStore";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { useFeedbackMessage } from "../composables/useFeedbackMessage";
+import { useTableSort, type SortColumn } from "../composables/useTableSort";
 import { useI18n } from "vue-i18n";
-import { Plus, Trash2, Bot, Hand, Info } from "lucide-vue-next";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  Plus,
+  Trash2,
+  Bot,
+  Hand,
+  Info,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+} from "lucide-vue-next";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -19,6 +29,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { captureError } from "../lib/sentry";
+import type { VocabularyEntry, VocabularySource } from "../types/vocabulary";
+
+type SortKey = "term" | "source" | "weight" | "createdAt";
 
 const vocabularyStore = useVocabularyStore();
 const settingsStore = useSettingsStore();
@@ -38,6 +51,69 @@ const showDuplicateHint = computed(
     newTermInput.value.trim() !== "" &&
     vocabularyStore.isDuplicateTerm(newTermInput.value),
 );
+
+// 手動優先：使用者自訂詞排在機器建議之前
+const SOURCE_RANK: Record<VocabularySource, number> = { manual: 0, ai: 1 };
+
+// SQLite created_at 為 UTC 且不帶時區後綴，附加 "Z" 確保以 UTC 解析
+const timestampOf = (entry: VocabularyEntry) =>
+  new Date(entry.createdAt + "Z").getTime();
+
+const sortColumns: SortColumn<VocabularyEntry, SortKey>[] = [
+  {
+    key: "term",
+    compare: (a, b) => a.term.localeCompare(b.term, locale.value),
+    defaultDirection: "asc",
+  },
+  {
+    key: "source",
+    compare: (a, b) => SOURCE_RANK[a.source] - SOURCE_RANK[b.source],
+    defaultDirection: "asc",
+  },
+  {
+    key: "weight",
+    compare: (a, b) => a.weight - b.weight,
+    defaultDirection: "desc",
+  },
+  {
+    key: "createdAt",
+    compare: (a, b) => timestampOf(a) - timestampOf(b),
+    defaultDirection: "desc",
+  },
+];
+
+// 固定次鍵：weight desc → createdAt desc → id asc
+// id 為全序鍵，保證排序決定性（避免同秒時間戳造成順序不定）
+const sortTieBreak = (a: VocabularyEntry, b: VocabularyEntry) =>
+  b.weight - a.weight ||
+  timestampOf(b) - timestampOf(a) ||
+  a.id.localeCompare(b.id);
+
+const { sortState, toggleSort, sortedList } = useTableSort<
+  VocabularyEntry,
+  SortKey
+>(
+  () => vocabularyStore.termList,
+  sortColumns,
+  { key: "weight", direction: "desc" },
+  sortTieBreak,
+);
+
+function sortIconFor(key: SortKey) {
+  if (sortState.value.key !== key) return ArrowUpDown;
+  return sortState.value.direction === "asc" ? ArrowUp : ArrowDown;
+}
+
+function ariaSortFor(key: SortKey): "ascending" | "descending" | "none" {
+  if (sortState.value.key !== key) return "none";
+  return sortState.value.direction === "asc" ? "ascending" : "descending";
+}
+
+function sourceLabel(source: VocabularySource): string {
+  return source === "ai"
+    ? t("dictionary.sourceAi")
+    : t("dictionary.sourceManual");
+}
 
 function getWeightVariant(weight: number): "default" | "secondary" | "outline" {
   if (weight >= 30) return "default";
@@ -140,6 +216,13 @@ onBeforeUnmount(() => {
         <div class="space-y-1 text-sm text-muted-foreground">
           <p>{{ $t("dictionary.description") }}</p>
           <p>{{ $t("dictionary.weightDescription", { limit: 50 }) }}</p>
+          <p v-if="vocabularyStore.aiSuggestedTermList.length === 0">
+            {{
+              settingsStore.isSmartDictionaryEnabled
+                ? $t("dictionary.noAiSuggestionsEnabled")
+                : $t("dictionary.noAiSuggestions")
+            }}
+          </p>
           <p>{{ $t("dictionary.importHint") }}</p>
         </div>
       </div>
@@ -170,44 +253,79 @@ onBeforeUnmount(() => {
       </Card>
     </div>
 
-    <!-- Dictionary sections -->
-    <div v-else class="mt-6 space-y-6">
-      <!-- AI Recommended Section -->
+    <!-- Dictionary table -->
+    <div v-else class="mt-6">
       <Card>
-        <CardHeader class="pb-3">
-          <div class="flex items-center gap-2">
-            <CardTitle class="text-base">
-              <Bot class="inline h-4 w-4 mr-1" />
-              {{ $t("dictionary.aiRecommended") }}
-            </CardTitle>
-            <Badge v-if="vocabularyStore.aiSuggestedTermList.length > 0" variant="secondary">
-              {{ $t("dictionary.aiTermCount", { count: vocabularyStore.aiSuggestedTermList.length }) }}
-            </Badge>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div
-            v-if="vocabularyStore.aiSuggestedTermList.length === 0"
-            class="py-4 text-center text-sm text-muted-foreground"
-          >
-            {{
-              settingsStore.isSmartDictionaryEnabled
-                ? $t("dictionary.noAiSuggestionsEnabled")
-                : $t("dictionary.noAiSuggestions")
-            }}
-          </div>
-          <Table v-else>
+        <CardContent class="pt-6">
+          <Table>
             <TableHeader>
               <TableRow>
-                <TableHead class="w-full">{{ $t("dictionary.termHeader") }}</TableHead>
-                <TableHead class="w-24 text-center">{{ $t("dictionary.weight") }}</TableHead>
-                <TableHead class="w-40">{{ $t("dictionary.dateHeader") }}</TableHead>
+                <TableHead class="w-full" :aria-sort="ariaSortFor('term')">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    class="-ml-2 h-8"
+                    data-testid="sort-term"
+                    @click="toggleSort('term')"
+                  >
+                    {{ $t("dictionary.termHeader") }}
+                    <component :is="sortIconFor('term')" class="ml-1 h-3.5 w-3.5" />
+                  </Button>
+                </TableHead>
+                <TableHead class="w-28" :aria-sort="ariaSortFor('source')">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    class="-ml-2 h-8"
+                    data-testid="sort-source"
+                    @click="toggleSort('source')"
+                  >
+                    {{ $t("dictionary.sourceHeader") }}
+                    <component :is="sortIconFor('source')" class="ml-1 h-3.5 w-3.5" />
+                  </Button>
+                </TableHead>
+                <TableHead class="w-24 text-center" :aria-sort="ariaSortFor('weight')">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    class="h-8"
+                    data-testid="sort-weight"
+                    @click="toggleSort('weight')"
+                  >
+                    {{ $t("dictionary.weight") }}
+                    <component :is="sortIconFor('weight')" class="ml-1 h-3.5 w-3.5" />
+                  </Button>
+                </TableHead>
+                <TableHead class="w-40" :aria-sort="ariaSortFor('createdAt')">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    class="-ml-2 h-8"
+                    data-testid="sort-date"
+                    @click="toggleSort('createdAt')"
+                  >
+                    {{ $t("dictionary.dateHeader") }}
+                    <component :is="sortIconFor('createdAt')" class="ml-1 h-3.5 w-3.5" />
+                  </Button>
+                </TableHead>
                 <TableHead class="w-20 text-right">{{ $t("dictionary.actionHeader") }}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              <TableRow v-for="entry in vocabularyStore.aiSuggestedTermList" :key="entry.id">
-                <TableCell class="font-medium text-foreground">{{ entry.term }}</TableCell>
+              <TableRow
+                v-for="entry in sortedList"
+                :key="entry.id"
+                :data-testid="`vocab-row-${entry.id}`"
+              >
+                <TableCell class="font-medium text-foreground" data-testid="vocab-term">
+                  {{ entry.term }}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" class="gap-1 font-normal" data-testid="vocab-source">
+                    <component :is="entry.source === 'ai' ? Bot : Hand" class="h-3 w-3" />
+                    {{ sourceLabel(entry.source) }}
+                  </Badge>
+                </TableCell>
                 <TableCell class="text-center">
                   <Badge :variant="getWeightVariant(entry.weight)">{{ entry.weight }}</Badge>
                 </TableCell>
@@ -226,51 +344,6 @@ onBeforeUnmount(() => {
               </TableRow>
             </TableBody>
           </Table>
-        </CardContent>
-      </Card>
-
-      <!-- Manual Section -->
-      <Card>
-        <CardHeader class="pb-3">
-          <CardTitle class="text-base">
-            <Hand class="inline h-4 w-4 mr-1" />
-            {{ $t("dictionary.manualAdded") }}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Table v-if="vocabularyStore.manualTermList.length > 0">
-            <TableHeader>
-              <TableRow>
-                <TableHead class="w-full">{{ $t("dictionary.termHeader") }}</TableHead>
-                <TableHead class="w-24 text-center">{{ $t("dictionary.weight") }}</TableHead>
-                <TableHead class="w-40">{{ $t("dictionary.dateHeader") }}</TableHead>
-                <TableHead class="w-20 text-right">{{ $t("dictionary.actionHeader") }}</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              <TableRow v-for="entry in vocabularyStore.manualTermList" :key="entry.id">
-                <TableCell class="font-medium text-foreground">{{ entry.term }}</TableCell>
-                <TableCell class="text-center">
-                  <Badge :variant="getWeightVariant(entry.weight)">{{ entry.weight }}</Badge>
-                </TableCell>
-                <TableCell class="text-muted-foreground">{{ formatDate(entry.createdAt) }}</TableCell>
-                <TableCell class="text-right">
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    class="text-destructive"
-                    :disabled="removingTermIdSet.has(entry.id)"
-                    @click="handleRemoveTerm(entry.id, entry.term)"
-                  >
-                    <Trash2 class="h-4 w-4" />
-                  </Button>
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-          <div v-else class="py-4 text-center text-sm text-muted-foreground">
-            {{ $t("dictionary.emptyState") }}
-          </div>
         </CardContent>
       </Card>
     </div>

--- a/tests/component/DictionaryView.test.ts
+++ b/tests/component/DictionaryView.test.ts
@@ -1,0 +1,187 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "../../src/i18n";
+import DictionaryView from "../../src/views/DictionaryView.vue";
+import { createVocabularyEntry } from "../support/factories/vocabulary-factory";
+import type { VocabularyEntry } from "../../src/types/vocabulary";
+
+vi.mock("../../src/lib/sentry", () => ({ captureError: vi.fn() }));
+
+let vocabState: Record<string, unknown>;
+let settingsState: Record<string, unknown>;
+
+vi.mock("../../src/stores/useVocabularyStore", () => ({
+  useVocabularyStore: () => vocabState,
+}));
+
+vi.mock("../../src/stores/useSettingsStore", () => ({
+  useSettingsStore: () => settingsState,
+}));
+
+function makeVocab(entries: VocabularyEntry[]): Record<string, unknown> {
+  return {
+    termList: entries,
+    termCount: entries.length,
+    aiSuggestedTermList: entries.filter((e) => e.source === "ai"),
+    isLoading: false,
+    isDuplicateTerm: vi.fn().mockReturnValue(false),
+    fetchTermList: vi.fn().mockResolvedValue(undefined),
+    addTerm: vi.fn().mockResolvedValue(undefined),
+    removeTerm: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** a: manual/10/01-01, b: ai/30/01-02, c: manual/10/01-03 */
+function sampleEntries(): VocabularyEntry[] {
+  return [
+    createVocabularyEntry({
+      id: "a",
+      term: "apple",
+      weight: 10,
+      source: "manual",
+      createdAt: "2026-01-01 00:00:00",
+    }),
+    createVocabularyEntry({
+      id: "b",
+      term: "banana",
+      weight: 30,
+      source: "ai",
+      createdAt: "2026-01-02 00:00:00",
+    }),
+    createVocabularyEntry({
+      id: "c",
+      term: "cherry",
+      weight: 10,
+      source: "manual",
+      createdAt: "2026-01-03 00:00:00",
+    }),
+  ];
+}
+
+function mountView() {
+  return mount(DictionaryView, {
+    global: {
+      plugins: [i18n],
+    },
+  });
+}
+
+/** 依渲染順序取出各列的 vocab id */
+function rowIds(wrapper: ReturnType<typeof mountView>): string[] {
+  return wrapper
+    .findAll('[data-testid^="vocab-row-"]')
+    .map((row) =>
+      (row.attributes("data-testid") ?? "").replace("vocab-row-", ""),
+    );
+}
+
+function ariaSortOf(
+  wrapper: ReturnType<typeof mountView>,
+  testid: string,
+): string | null | undefined {
+  const th = wrapper.get(`[data-testid="${testid}"]`).element.closest("th");
+  return th?.getAttribute("aria-sort");
+}
+
+beforeEach(() => {
+  vocabState = makeVocab(sampleEntries());
+  settingsState = { isSmartDictionaryEnabled: false };
+});
+
+describe("DictionaryView", () => {
+  it("[P1] renders a single table with all terms (initial weight desc)", () => {
+    const wrapper = mountView();
+    // 單一表格：只有一個 <table>
+    expect(wrapper.findAll("table")).toHaveLength(1);
+    // 初始 weight desc: b(30), then c & a (10) tie -> createdAt desc -> c, a
+    expect(rowIds(wrapper)).toEqual(["b", "c", "a"]);
+  });
+
+  it("[P1] toggles weight ascending when clicking the weight header", async () => {
+    const wrapper = mountView();
+    await wrapper.get('[data-testid="sort-weight"]').trigger("click");
+    // weight asc: 10s first (c before a via tieBreak), then b(30)
+    expect(rowIds(wrapper)).toEqual(["c", "a", "b"]);
+  });
+
+  it("[P2] sorts by source with manual-first precedence", async () => {
+    const wrapper = mountView();
+    await wrapper.get('[data-testid="sort-source"]').trigger("click");
+    // asc manual-first: manual (c,a via tieBreak) then ai (b)
+    expect(rowIds(wrapper)).toEqual(["c", "a", "b"]);
+
+    await wrapper.get('[data-testid="sort-source"]').trigger("click");
+    // desc: ai first
+    expect(rowIds(wrapper)).toEqual(["b", "c", "a"]);
+  });
+
+  it("[P2] sorts by term alphabetically", async () => {
+    const wrapper = mountView();
+    await wrapper.get('[data-testid="sort-term"]').trigger("click");
+    expect(rowIds(wrapper)).toEqual(["a", "b", "c"]);
+
+    await wrapper.get('[data-testid="sort-term"]').trigger("click");
+    expect(rowIds(wrapper)).toEqual(["c", "b", "a"]);
+  });
+
+  it("[P2] renders localized source labels with badges", () => {
+    const wrapper = mountView();
+    const text = wrapper.text();
+    expect(text).toContain(i18n.global.t("dictionary.sourceManual"));
+    expect(text).toContain(i18n.global.t("dictionary.sourceAi"));
+    // 每列都有來源 badge
+    expect(wrapper.findAll('[data-testid="vocab-source"]')).toHaveLength(3);
+  });
+
+  it("[P1] reflects aria-sort only on the active column", async () => {
+    const wrapper = mountView();
+    // 初始：weight 欄為 descending，其餘 none
+    expect(ariaSortOf(wrapper, "sort-weight")).toBe("descending");
+    expect(ariaSortOf(wrapper, "sort-term")).toBe("none");
+    expect(ariaSortOf(wrapper, "sort-source")).toBe("none");
+    expect(ariaSortOf(wrapper, "sort-date")).toBe("none");
+
+    await wrapper.get('[data-testid="sort-term"]').trigger("click");
+    // 切到 term asc；weight 回 none
+    expect(ariaSortOf(wrapper, "sort-term")).toBe("ascending");
+    expect(ariaSortOf(wrapper, "sort-weight")).toBe("none");
+  });
+
+  it("[P2] keeps deterministic order for equal weight and timestamp", () => {
+    vocabState = makeVocab([
+      createVocabularyEntry({
+        id: "y2",
+        term: "same-two",
+        weight: 5,
+        source: "manual",
+        createdAt: "2026-05-05 00:00:00",
+      }),
+      createVocabularyEntry({
+        id: "x1",
+        term: "same-one",
+        weight: 5,
+        source: "manual",
+        createdAt: "2026-05-05 00:00:00",
+      }),
+    ]);
+    const wrapper = mountView();
+    // tieBreak 最終以 id asc 收尾 -> x1 before y2
+    expect(rowIds(wrapper)).toEqual(["x1", "y2"]);
+  });
+
+  it("[P2] does not show the 'no AI suggestions' hint when AI terms exist", () => {
+    // b 為 ai 來源 → 已有 AI 詞，即使智慧學習關閉也不應顯示「尚無 AI 推薦詞彙」（避免與表格矛盾）
+    settingsState = { isSmartDictionaryEnabled: false };
+    const wrapper = mountView();
+    expect(wrapper.text()).not.toContain(
+      i18n.global.t("dictionary.noAiSuggestions"),
+    );
+  });
+
+  it("[P2] renders empty state when there are no terms", () => {
+    vocabState = makeVocab([]);
+    const wrapper = mountView();
+    expect(wrapper.findAll("table")).toHaveLength(0);
+    expect(wrapper.text()).toContain(i18n.global.t("dictionary.emptyState"));
+  });
+});

--- a/tests/support/factories/vocabulary-factory.ts
+++ b/tests/support/factories/vocabulary-factory.ts
@@ -1,16 +1,16 @@
 import { faker } from "@faker-js/faker";
+import type { VocabularyEntry } from "../../../src/types/vocabulary";
 
-export type VocabularyEntry = {
-  id: string;
-  term: string;
-  createdAt: string;
-};
+export type { VocabularyEntry };
 
 export const createVocabularyEntry = (
   overrides: Partial<VocabularyEntry> = {},
 ): VocabularyEntry => ({
   id: faker.string.uuid(),
   term: faker.word.noun(),
-  createdAt: new Date().toISOString(),
+  weight: faker.number.int({ min: 0, max: 50 }),
+  source: "manual",
+  // SQLite 格式（UTC，無時區後綴），與真實 store 一致，供 createdAt 排序正確解析
+  createdAt: faker.date.recent().toISOString().slice(0, 19).replace("T", " "),
   ...overrides,
 });

--- a/tests/unit/use-table-sort.test.ts
+++ b/tests/unit/use-table-sort.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+import { ref } from "vue";
+import {
+  useTableSort,
+  type SortColumn,
+} from "../../src/composables/useTableSort";
+import { createVocabularyEntry } from "../support/factories/vocabulary-factory";
+import type {
+  VocabularyEntry,
+  VocabularySource,
+} from "../../src/types/vocabulary";
+
+const SOURCE_RANK: Record<VocabularySource, number> = { manual: 0, ai: 1 };
+
+const tsOf = (e: VocabularyEntry) => new Date(e.createdAt + "Z").getTime();
+
+function buildColumns(): SortColumn<VocabularyEntry, string>[] {
+  return [
+    {
+      key: "term",
+      compare: (a, b) => a.term.localeCompare(b.term),
+      defaultDirection: "asc",
+    },
+    {
+      key: "weight",
+      compare: (a, b) => a.weight - b.weight,
+      defaultDirection: "desc",
+    },
+    {
+      key: "createdAt",
+      compare: (a, b) => tsOf(a) - tsOf(b),
+      defaultDirection: "desc",
+    },
+    {
+      key: "source",
+      compare: (a, b) => SOURCE_RANK[a.source] - SOURCE_RANK[b.source],
+      defaultDirection: "asc",
+    },
+  ];
+}
+
+// 固定 tieBreak：weight desc → createdAt desc → id asc（全序，保證決定性）
+const tieBreak = (a: VocabularyEntry, b: VocabularyEntry) =>
+  b.weight - a.weight || tsOf(b) - tsOf(a) || a.id.localeCompare(b.id);
+
+const ids = (list: VocabularyEntry[]) => list.map((e) => e.id);
+
+/** a: manual/10/01-01, b: ai/30/01-02, c: manual/10/01-03 */
+function sampleEntries(): VocabularyEntry[] {
+  return [
+    createVocabularyEntry({
+      id: "a",
+      term: "apple",
+      weight: 10,
+      source: "manual",
+      createdAt: "2026-01-01 00:00:00",
+    }),
+    createVocabularyEntry({
+      id: "b",
+      term: "banana",
+      weight: 30,
+      source: "ai",
+      createdAt: "2026-01-02 00:00:00",
+    }),
+    createVocabularyEntry({
+      id: "c",
+      term: "cherry",
+      weight: 10,
+      source: "manual",
+      createdAt: "2026-01-03 00:00:00",
+    }),
+  ];
+}
+
+describe("useTableSort", () => {
+  it("[P1] initial state sorts by the given key/direction (weight desc)", () => {
+    const entries = ref(sampleEntries());
+    const { sortedList } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "weight", direction: "desc" },
+      tieBreak,
+    );
+    // b(30) first; tie between a & c (weight 10) -> createdAt desc -> c before a
+    expect(ids(sortedList.value)).toEqual(["b", "c", "a"]);
+  });
+
+  it("[P1] toggleSort flips direction on the same column", () => {
+    const entries = ref(sampleEntries());
+    const { sortState, toggleSort, sortedList } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "weight", direction: "desc" },
+      tieBreak,
+    );
+
+    toggleSort("weight");
+    expect(sortState.value).toEqual({ key: "weight", direction: "asc" });
+    // weight asc: 10s first (c before a via tieBreak), then b(30)
+    expect(ids(sortedList.value)).toEqual(["c", "a", "b"]);
+
+    toggleSort("weight");
+    expect(sortState.value).toEqual({ key: "weight", direction: "desc" });
+    expect(ids(sortedList.value)).toEqual(["b", "c", "a"]);
+  });
+
+  it("[P1] switching column applies that column's defaultDirection", () => {
+    const entries = ref(sampleEntries());
+    const { sortState, toggleSort } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "weight", direction: "desc" },
+      tieBreak,
+    );
+
+    toggleSort("term"); // term defaultDirection = asc
+    expect(sortState.value).toEqual({ key: "term", direction: "asc" });
+
+    toggleSort("createdAt"); // createdAt defaultDirection = desc
+    expect(sortState.value).toEqual({ key: "createdAt", direction: "desc" });
+
+    toggleSort("source"); // source defaultDirection = asc
+    expect(sortState.value).toEqual({ key: "source", direction: "asc" });
+  });
+
+  it("[P2] sorts by term ascending and descending", () => {
+    const entries = ref(sampleEntries());
+    const { toggleSort, sortedList } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "term", direction: "asc" },
+      tieBreak,
+    );
+    expect(ids(sortedList.value)).toEqual(["a", "b", "c"]);
+
+    toggleSort("term");
+    expect(ids(sortedList.value)).toEqual(["c", "b", "a"]);
+  });
+
+  it("[P2] sorts by source with manual-first precedence", () => {
+    const entries = ref(sampleEntries());
+    const { toggleSort, sortedList } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "source", direction: "asc" },
+      tieBreak,
+    );
+    // asc: manual (a,c) before ai (b); within manual -> tieBreak c before a
+    expect(ids(sortedList.value)).toEqual(["c", "a", "b"]);
+
+    toggleSort("source"); // desc: ai first
+    expect(ids(sortedList.value)).toEqual(["b", "c", "a"]);
+  });
+
+  it("[P2] sorts by createdAt ascending and descending", () => {
+    const entries = ref(sampleEntries());
+    const { toggleSort, sortedList } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "createdAt", direction: "desc" },
+      tieBreak,
+    );
+    expect(ids(sortedList.value)).toEqual(["c", "b", "a"]);
+
+    toggleSort("createdAt");
+    expect(ids(sortedList.value)).toEqual(["a", "b", "c"]);
+  });
+
+  it("[P1] tieBreak is stable and NOT reversed by descending direction", () => {
+    // 兩筆同 weight、同 createdAt，只差 id -> 必定以 id asc 收尾，方向不影響 tie
+    const entries = ref([
+      createVocabularyEntry({
+        id: "y2",
+        weight: 5,
+        source: "manual",
+        createdAt: "2026-05-05 00:00:00",
+      }),
+      createVocabularyEntry({
+        id: "x1",
+        weight: 5,
+        source: "manual",
+        createdAt: "2026-05-05 00:00:00",
+      }),
+    ]);
+    const { toggleSort, sortedList } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "weight", direction: "desc" },
+      tieBreak,
+    );
+    expect(ids(sortedList.value)).toEqual(["x1", "y2"]);
+
+    toggleSort("weight"); // asc - tieBreak must still yield id asc
+    expect(ids(sortedList.value)).toEqual(["x1", "y2"]);
+  });
+
+  it("[P1] re-sorts when a reactive value read inside the comparator changes", () => {
+    // 模擬 i18n locale 響應式：comparator 讀外部 ref，改變後 sortedList 應重排
+    const flip = ref(false);
+    const entries = ref([
+      createVocabularyEntry({ id: "1", weight: 1 }),
+      createVocabularyEntry({ id: "2", weight: 2 }),
+    ]);
+    const columns: SortColumn<VocabularyEntry, string>[] = [
+      {
+        key: "reactive",
+        compare: (a, b) => (a.weight - b.weight) * (flip.value ? -1 : 1),
+        defaultDirection: "asc",
+      },
+    ];
+    const { sortedList } = useTableSort(
+      () => entries.value,
+      columns,
+      { key: "reactive", direction: "asc" },
+      tieBreak,
+    );
+    expect(ids(sortedList.value)).toEqual(["1", "2"]);
+
+    flip.value = true;
+    expect(ids(sortedList.value)).toEqual(["2", "1"]);
+  });
+
+  it("[P2] re-sorts when the source list changes", () => {
+    const entries = ref([
+      createVocabularyEntry({ id: "1", weight: 1 }),
+      createVocabularyEntry({ id: "2", weight: 2 }),
+    ]);
+    const { sortedList } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "weight", direction: "desc" },
+      tieBreak,
+    );
+    expect(ids(sortedList.value)).toEqual(["2", "1"]);
+
+    entries.value = [
+      ...entries.value,
+      createVocabularyEntry({ id: "3", weight: 3 }),
+    ];
+    expect(ids(sortedList.value)).toEqual(["3", "2", "1"]);
+  });
+
+  it("[P2] does not mutate the source list", () => {
+    const original = sampleEntries();
+    const entries = ref(original);
+    const { sortedList } = useTableSort(
+      () => entries.value,
+      buildColumns(),
+      { key: "weight", direction: "desc" },
+      tieBreak,
+    );
+    void sortedList.value;
+    expect(ids(entries.value)).toEqual(["a", "b", "c"]);
+  });
+
+  it("[P3] handles empty and single-item lists", () => {
+    const empty = ref<VocabularyEntry[]>([]);
+    const emptySort = useTableSort(
+      () => empty.value,
+      buildColumns(),
+      { key: "weight", direction: "desc" },
+      tieBreak,
+    );
+    expect(emptySort.sortedList.value).toEqual([]);
+
+    const one = ref([createVocabularyEntry({ id: "only", weight: 7 })]);
+    const { sortedList } = useTableSort(
+      () => one.value,
+      buildColumns(),
+      { key: "weight", direction: "desc" },
+      tieBreak,
+    );
+    expect(ids(sortedList.value)).toEqual(["only"]);
+  });
+});


### PR DESCRIPTION
## 摘要

將自訂字典的「AI 推薦」與「手動新增」兩個分離表格**合併為單一表格**，並新增可排序的「來源」欄。詞彙／來源／權重／新增時間**四欄皆可點表頭排序**（二態切換：升冪 ⇄ 降冪），初始維持權重降冪。

此設計讓「依來源排序」真正具語意（原雙表架構下同表來源相同、無法排序）。

## 變更內容

- **新增 `useTableSort` composable**（`src/composables/useTableSort.ts`）
  - Client-side 排序；方向 factor 只作用於主鍵比較。
  - 固定 `tieBreak` 三層鏈 `weight desc → createdAt desc → id asc`，以 `id` 全序鍵確保排序**決定性**（避免同秒時間戳造成順序不定）。
  - `toggleSort`：同欄翻轉方向、換欄套用該欄 `defaultDirection`。
- **重構 `DictionaryView.vue` 為單一表格**
  - 欄序 詞彙／來源／權重／時間／操作；來源欄以 `Badge` + icon 呈現。
  - 可排序表頭用 `Button` + lucide 箭頭 icon + `TableHead` 上 `aria-sort`（僅標 active 欄）+ `data-testid`。
  - 每欄自訂首點方向（詞彙 asc；權重／時間 desc；來源 asc）；來源用 precedence map `{ manual: 0, ai: 1 }`「手動優先」。
  - 智慧學習提示移至說明區，且僅在無 AI 詞時顯示，避免與表格內容矛盾。
- **i18n 五語系**（zh-TW/zh-CN/en/ja/ko）：新增 `sourceHeader`/`sourceManual`/`sourceAi`；移除 `aiRecommended`/`manualAdded`/`aiTermCount`（合併後失去引用）。
- **測試**：新增 `useTableSort` 單元測試（11）與 `DictionaryView` 元件測試（9）；擴充 vocabulary factory 對齊型別（`weight`/`source`）。

## 設計決策

- **Client-side 排序**：字典資料量小、在記憶體，不動 SQL/DB/IPC。
- **排序狀態不 persist**（view-local）：離開頁面重置為權重降冪。
- 不改 DB schema／IPC（無需 migration／ipc-review）。

## 驗證

- `npx vue-tsc --noEmit` ✅
- `pnpm exec eslint src` ✅
- `pnpm exec vitest run` ✅ 613/613 全數通過
- 經 **Council（adversarial code-review）+ Rubber Duck** 雙重審查，發現的矛盾提示問題已修正並補測試，死鍵已移除。