### PR TITLE
fix(chart): 每日使用趨勢 tooltip 使用量為 0 時顯示 0 而非空白

### DIFF
--- a/src/components/ui/chart/ChartTooltipContent.vue
+++ b/src/components/ui/chart/ChartTooltipContent.vue
@@ -94,7 +94,7 @@ const tooltipLabel = computed(() => {
                 {{ itemConfig?.label || value }}
               </span>
             </div>
-            <span v-if="value" class="text-foreground font-mono font-medium tabular-nums">
+            <span v-if="value !== undefined && value !== null" class="text-foreground font-mono font-medium tabular-nums">
               {{ value.toLocaleString() }}
             </span>
           </div>

--- a/tests/component/ChartTooltipContent.test.ts
+++ b/tests/component/ChartTooltipContent.test.ts
@@ -1,0 +1,51 @@
+import { mount } from "@vue/test-utils";
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
+import ChartTooltipContent from "../../src/components/ui/chart/ChartTooltipContent.vue";
+
+const LABEL = "使用次數";
+const config = { count: { label: LABEL, color: "#22c55e" } };
+
+// 只掛載 tooltip 內容元件，直接餵入 unovis crosshair 會傳入的 payload 形狀（{ count: number }）。
+function mountTooltip(value: number | null | undefined) {
+  return mount(ChartTooltipContent, {
+    props: {
+      payload: { count: value },
+      config,
+      indicator: "dot" as const,
+    },
+  });
+}
+
+describe("ChartTooltipContent 數值渲染", () => {
+  // 回歸保護：修正前 `v-if="value"` 會把 0 當 falsy，導致當天無使用量時只剩 label、數字空白。
+  it("[P1] value=0 仍渲染數值（顯示 0 而非空白），且保留 label 該列", () => {
+    const wrapper = mountTooltip(0);
+
+    const valueSpan = wrapper.find(".tabular-nums");
+    expect(valueSpan.exists()).toBe(true);
+    expect(valueSpan.text()).toBe((0).toLocaleString());
+    // label 那列（截圖中的「使用次數」）仍在，還原完整 tooltip 情境。
+    expect(wrapper.text()).toContain(LABEL);
+  });
+
+  it("[P1] value>0 正常渲染數值", () => {
+    const count = faker.number.int({ min: 1, max: 999 });
+    const wrapper = mountTooltip(count);
+
+    const valueSpan = wrapper.find(".tabular-nums");
+    expect(valueSpan.exists()).toBe(true);
+    expect(valueSpan.text()).toBe(count.toLocaleString());
+  });
+
+  it("[P2] value=undefined 不渲染數值 span（避免對 undefined 呼叫 toLocaleString）", () => {
+    const wrapper = mountTooltip(undefined);
+    expect(wrapper.find(".tabular-nums").exists()).toBe(false);
+    expect(wrapper.text()).toContain(LABEL);
+  });
+
+  it("[P2] value=null 不渲染數值 span", () => {
+    const wrapper = mountTooltip(null);
+    expect(wrapper.find(".tabular-nums").exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
## 問題

每日使用趨勢圖，當天沒有使用量時，tooltip 只顯示「使用次數」標籤、右側數字空白（無數字）。

## 根因

`src/components/ui/chart/ChartTooltipContent.vue` 的數值 span 以 `v-if="value"` 控制，`value === 0` 被當成 falsy，導致零值當天的數字不渲染。資料層（`buildDailyUsageSeries`）本就已將缺席日補成 `count=0`，故此為純顯示層問題，而非補零缺漏。

## 修正

- 將 `v-if="value"` 改為 `v-if="value !== undefined && value !== null"`，讓 `0` 正常顯示，同時保留 null/undefined 不呼叫 `toLocaleString()` 的保護。
- 此 tooltip 元件唯一使用者為 `DashboardUsageChart.vue`，無外溢至其他圖表的風險。

## 測試

- 新增 `tests/component/ChartTooltipContent.test.ts`：斷言 `value=0` 顯示「0」（且保留 label 列）、`value>0` 顯示數字、`null`/`undefined` 不渲染數值 span。期待值以 `toLocaleString()` 表示，避免 locale 差異造成誤敗。

## 範圍界定

- 不涉及 Rust / IPC / SQL / i18n。
- 「整段期間完全無使用記錄」維持既有「尚無使用記錄」空狀態（刻意設計），與本次單日零值無關，未變更。