### PR TITLE
fix(models): GPT OSS 120B 標籤由「成本高」改為「正式版」

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ SayIt 版本更新紀錄。
 - 智慧字典學習在 Windows 上改為預設啟用。這個開關的預設值一直停在功能初版的判斷式（只有 macOS 啟用），理由是當時 Windows 還讀不到游標所在的輸入框；後來 Windows 版改用 UI Automation 補上讀取能力後，預設值卻沒有跟著更新，等於 Windows 使用者一直拿不到一個其實已經可以運作的功能。升級摘要彈窗會說明這項變更，不需要的話可在設定頁關閉。
 - 補正 `text_field_reader` 的相關文件：文字場讀取早已不是 macOS 專屬（macOS 走 AXUIElement、Windows 走 UI Automation），且密碼欄位守衛在兩個平台**並不對稱**——Windows 以 `CurrentIsPassword` fail-closed 排除，macOS 目前僅以 `AXRole` 過濾、不檢查 `AXSubrole`，倚賴系統不對 secure field 暴露 `AXValue`。
 
+### Fixed
+
+- 修正模型清單中 GPT OSS 120B 的標籤：原本標「穩定可靠 · 成本高」，但這個模型的價格是 $0.15/$0.60，在全部可選模型裡第二便宜，比預設的 Qwen3.6 27B（$0.6/$3.0）還便宜 4 到 5 倍；而且 Groq 的三個模型都有免費額度，成本本來就不是這裡要區分的東西。真正的差別在於預設模型是 Groq preview、可能無預警下架，而這個是正式版。標籤改為「穩定 · 正式版」，i18n key 也一併從 `stableCostly` 改名為 `stableProduction`，避免日後又照著鍵名把文案改回成本敘述。
+
 ## [0.14.0] - 2026-07-29
 
 ### Added

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -131,7 +131,7 @@
       "accurate": "Accuracy first",
       "highQuota": "Highest free quota",
       "balanced": "Balanced · Default",
-      "stableCostly": "Stable · Costly",
+      "stableProduction": "Stable · Production",
       "fastCheap": "Fastest · Cheapest",
       "smartestSlow": "Smartest · Slower",
       "premium": "Premium"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -131,7 +131,7 @@
       "accurate": "精度優先",
       "highQuota": "無料枠が最大",
       "balanced": "バランス · デフォルト",
-      "stableCostly": "安定 · 高コスト",
+      "stableProduction": "安定 · 正式版",
       "fastCheap": "最速 · 最安",
       "smartestSlow": "最賢 · 低速",
       "premium": "高品質"

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -131,7 +131,7 @@
       "accurate": "정확도 우선",
       "highQuota": "무료 할당량 최대",
       "balanced": "균형 · 기본",
-      "stableCostly": "안정 · 고비용",
+      "stableProduction": "안정 · 정식 버전",
       "fastCheap": "가장 빠름 · 가장 저렴",
       "smartestSlow": "가장 똑똑 · 느림",
       "premium": "프리미엄"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -131,7 +131,7 @@
       "accurate": "准确度优先",
       "highQuota": "免费额度最高",
       "balanced": "平衡 · 默认",
-      "stableCostly": "稳定可靠 · 成本高",
+      "stableProduction": "稳定 · 正式版",
       "fastCheap": "最快 · 最便宜",
       "smartestSlow": "最聪明 · 较慢",
       "premium": "高品质"

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -131,7 +131,7 @@
       "accurate": "準確度優先",
       "highQuota": "免費額度最高",
       "balanced": "平衡 · 預設",
-      "stableCostly": "穩定可靠 · 成本高",
+      "stableProduction": "穩定 · 正式版",
       "fastCheap": "最快 · 最便宜",
       "smartestSlow": "最聰明 · 較慢",
       "premium": "高品質"

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -198,7 +198,10 @@ export const LLM_MODEL_LIST: LlmModelConfig[] = [
     id: "openai/gpt-oss-120b",
     providerId: "groq",
     displayName: "GPT OSS 120B",
-    badgeKey: "settings.modelBadge.stableCostly",
+    // badge 是「正式版」而非「成本高」：本模型 $0.15/$0.60 是全 registry 第二便宜
+    // （僅次於 20B），且 Groq 三個模型都有免費額度，成本不是這裡的區分軸。
+    // 真正的差異是預設的 qwen 為 preview（可能無預警下架），本模型是正式版。
+    badgeKey: "settings.modelBadge.stableProduction",
     descriptionKey: "settings.model.llmDescription.oss120b",
     speedTps: 500,
     inputCostPerMillion: 0.15,


### PR DESCRIPTION
## 摘要

模型清單裡 `openai/gpt-oss-120b` 掛的 badge 是「穩定可靠 · 成本高 / Stable · Costly」，但這個標示與事實相反，會誤導使用者的選型決策。

## 事實依據

從 `modelRegistry.ts` 抽出全部 11 個模型的價格比對：

| provider | model | badge | input $/M | output $/M |
|---|---|---|---|---|
| groq | qwen/qwen3.6-27b（**預設**） | balanced | 0.6 | 3.0 |
| groq | **openai/gpt-oss-120b** | **stableCostly** | **0.15** | **0.60** |
| groq | openai/gpt-oss-20b | fastCheap | 0.075 | 0.3 |
| gemini | gemini-3.6-flash | premium | 1.5 | 7.5 |
| gemini | gemini-3.5-flash | premium | 1.5 | 9.0 |
| gemini | gemini-3.5-flash-lite | highQuota | 0.3 | 2.5 |
| gemini | gemini-3.1-flash-lite | fastCheap | 0.25 | 1.5 |
| gemini | gemini-3.1-pro-preview | smartestSlow | 2.0 | 12.0 |
| openai | gpt-5.6-luna | premium | 1.0 | 6.0 |
| openai | gpt-5.4-nano | fastCheap | 0.2 | 1.25 |
| anthropic | claude-haiku-4-5 | premium | 1.0 | 5.0 |

三個問題：

1. **它是全 registry 第二便宜的模型**（僅次於 gpt-oss-20b），比預設的 qwen3.6-27b 便宜 4～5 倍。標成「成本高」是事實錯誤。
2. **成本根本不是這裡的區分軸**：Groq 三個模型都有 `freeQuotaRpd: 1000` 免費額度。
3. **真正的差異在描述裡就寫了**：預設的 qwen 是「Groq preview 模型，可能無預警下架」（`llmDescription.qwen`），而本模型是「輸出較穩定」（`llmDescription.oss120b`）。所以正確的對照是 **preview vs 正式版**，不是便宜 vs 貴。

## 變更內容

- badge 文案改為「穩定 · 正式版 / Stable · Production」（五語系）
- i18n key `stableCostly` → `stableProduction`
- `modelRegistry.ts` 加註解記錄判斷依據

**為什麼連 key 一起改名**：若只改值不改鍵名，會留下一個名為 `Costly` 但內容是「正式版」的 key，日後維護者很容易照著鍵名把文案改回成本敘述。考慮過只改值（與上游一致、diff 最小）與只改值加註解兩個方案，但兩者都留著這個矛盾，改名的成本只是多動 6 行，值得。

## 驗證

- `npx vue-tsc --noEmit` → exit 0
- `pnpm exec eslint src` → exit 0
- `pnpm exec vitest run --no-file-parallelism` → **42 files / 696 tests 全過**
- 全 repo grep `stableCostly` → **0 命中**（無殘留孤兒 key）
- 腳本檢查：`modelRegistry.ts` 使用的 7 個 badge key 在五語系皆有定義，且五語系都沒有未被使用的 orphan key
- Rust 未改動，不需跑 `cargo test`
