### PR TITLE
fix(deps): apple-native-keyring-store 補上必要的 keychain feature

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -268,6 +268,7 @@ checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
 dependencies = [
  "keyring-core",
  "log",
+ "security-framework",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,7 +42,11 @@ base64 = "0.23.0"
 core-graphics = "0.24"
 core-foundation = "0.10"
 objc = "0.2"
-apple-native-keyring-store = "1"
+# keychain feature 為必要：crate 在 macOS 上若未啟用 `keychain` 或 `protected`
+# 會直接 compile_error!。選 `keychain`（legacy keychain）而非 `protected`——
+# 後者要求 app 是 sandboxed，部分功能還需要 provisioning profile，
+# 而本 fork 的 macOS build 未簽名，拿不到那些條件。
+apple-native-keyring-store = { version = "1", features = ["keychain"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61", features = [


### PR DESCRIPTION
## 問題

PR #84 merge 進 main 後，CI 在 macOS 失敗（exit 101），Windows job 被連帶取消：

```
error: At least one of the `keychain` or `protected` features must be enabled on macOS
  --> apple-native-keyring-store-1.0.1/src/lib.rs:40:1
error: could not compile `apple-native-keyring-store` (lib) due to 1 previous error
```

加入 keyring 相依時沒有指定 feature，而該 crate 沒有 default features，等於 **macOS 版根本編譯不出來**。開發機是 Windows，本機驗證涵蓋不到這條路徑。

## 修法

`src-tauri/Cargo.toml`：

```toml
apple-native-keyring-store = { version = "1", features = ["keychain"] }
```

**為什麼選 `keychain` 而不是 `protected`**（依 crate 官方文件）：

| feature | store | 條件 |
|---|---|---|
| `keychain` | legacy keychain（加密檔案） | available to **all** applications |
| `protected` | protected data store | 需 **sandboxed** app（macOS 10.15+），部分功能還需 provisioning profile |

本 fork 的 macOS build **未簽名**（無 Apple Developer 憑證），不是 sandboxed、也沒有 provisioning profile，拿不到 `protected` 的條件。而且 `secret_store.rs` 實際使用的就是 `apple_native_keyring_store::keychain::Store`，兩者一致。

## Cargo.lock

由 cargo 自行解析更新，**只多一行**——`apple-native-keyring-store` 的 `dependencies` 加上 `security-framework`（該 crate 原本就在 lock 裡，被其他相依用到）。未變動任何相依版本。

## 驗證

```
cargo metadata --locked        exit 0（lock 與 Cargo.toml 一致）
cargo clippy -D warnings       0 warning（Windows）
cargo test --workspace         207 passed（Windows）
```

macOS 端由 CI 驗證。
