### PR TITLE
fix(macos): 修正 clippy unused_mut 並補上開瀏覽器的絕對路徑

### DIFF
--- a/src-tauri/src/plugins/azure_user_auth.rs
+++ b/src-tauri/src/plugins/azure_user_auth.rs
@@ -479,7 +479,9 @@ pub fn open_in_browser(url: &str) -> Result<(), AzureUserAuthError> {
 
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
+        // 同上，用絕對路徑而非相對程式名，避免 PATH 被污染時被替換掉。
+        // `/usr/bin/open` 是系統二進位，受 SIP 保護。
+        std::process::Command::new("/usr/bin/open")
             .arg(url)
             .spawn()
             .map_err(|e| AzureUserAuthError::Failed(format!("failed to open browser: {e}")))?;

--- a/src-tauri/src/plugins/secret_store.rs
+++ b/src-tauri/src/plugins/secret_store.rs
@@ -103,6 +103,10 @@ impl OsKeyring {
 
     fn entry(&self, account: &str) -> Result<keyring_core::Entry, String> {
         ensure_store()?;
+        // 只有 Windows 分支會 insert，其他平台這個 binding 不需要 mut——
+        // 但仍要留著 mut 讓 Windows 能寫入，故在非 Windows 抑制該警告
+        // （clippy 以 -D warnings 跑，不抑制會直接讓 macOS CI 失敗）。
+        #[cfg_attr(not(target_os = "windows"), allow(unused_mut))]
         let mut modifiers: HashMap<&str, &str> = HashMap::new();
         // Windows 憑證管理員預設是 Enterprise persistence——那會讓憑證隨
         // 使用者設定檔漫遊到其他機器。refresh token 不該離開這台裝置，


### PR DESCRIPTION
## 問題

PR #85 修好 macOS 的編譯錯誤後，CI 進到 clippy 階段又失敗（exit 101）：

```
error: variable does not need to be mutable
error: could not compile `sayit` (lib) due to 1 previous error
```

`secret_store.rs` 的 `let mut modifiers` 只有 Windows 分支會 `insert`，其他平台這個 binding 不需要 `mut`。CI 的 clippy 以 `-D warnings` 執行，警告即失敗。

## 修法

### 1. `secret_store.rs`：cfg 條件式抑制

不能單純拿掉 `mut`——Windows 仍要寫入。改為只在非 Windows 抑制：

```rust
#[cfg_attr(not(target_os = "windows"), allow(unused_mut))]
let mut modifiers: HashMap<&str, &str> = HashMap::new();
```

這樣 Windows 上仍能偵測到真正多餘的 `mut`，不是無差別 allow。

### 2. `azure_user_auth.rs`：macOS 開瀏覽器改用絕對路徑（順手補的同類遺漏）

Windows 分支特意用 `%SystemRoot%\System32\rundll32.exe` 絕對路徑，註解寫明理由是「相對程式名會走 CreateProcess 的搜尋順序，屬 binary planting 的可乘之機」；但 macOS 分支仍是相對名 `open`，會走 PATH 搜尋——同一個顧慮沒被涵蓋。改用 `/usr/bin/open`（系統二進位，受 SIP 保護）。

Linux 分支維持 `xdg-open`：絕對路徑因發行版而異，且 `ensure_store()` 在非 Windows/macOS 一律回錯，走不到登入流程。

## 一併確認（避免再來一輪 CI）

- 掃過三個新增 Rust 檔案的所有 `cfg` 分支，未再發現平台條件式造成的 unused 警告
- `secret_store` 的測試全部使用 `FakeKeyring` / `ManifestDeleteFails`，**不碰真實 keychain**（`OsKeyring` 只出現在 production 路徑 `store()`），因此 macOS 的 `cargo test` 不會因 runner keychain 鎖定而失敗

## 驗證

```
cargo clippy -D warnings       0 warning（Windows）
cargo test --workspace         207 passed（Windows）
cargo fmt --all --check        clean
```

macOS 端由 CI 驗證。
