### PR TITLE
fix(ci): 修正 release 競態導致 ARM updater 資產遺失

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,83 @@ permissions:
   contents: write
 
 jobs:
+  # 先建立唯一的 draft release，再讓三個平台的 build job 上傳到它。
+  #
+  # 先前三個 build job 各自呼叫 tauri-action 且都帶 releaseDraft: true、
+  # 沒有指定 releaseId；tauri-action 的行為是「找同 tag 的 draft，找不到就建一個」，
+  # 三個 job 幾乎同時啟動時都看不到彼此，於是**建出多個同 tag 的 release**。
+  # 資產與 latest.json 因此被拆散到不同 release，publish-release 只發佈其中一個，
+  # 另一個連同 ARM 的 updater 檔案永遠留在 draft ——
+  # Apple Silicon 使用者收不到自動更新（v0.15.2 實際發生過）。
+  create-release:
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve release metadata
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW_TAG="${{ inputs.tag }}"
+          else
+            RAW_TAG="${GITHUB_REF_NAME}"
+          fi
+
+          RAW_TAG="${RAW_TAG#refs/tags/}"
+          RELEASE_VERSION="${RAW_TAG#v}"
+
+          echo "RELEASE_TAG=$RAW_TAG" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_ENV"
+
+          NOTES=$(awk -v ver="$RELEASE_VERSION" '
+            $0 ~ ("^## \\[" ver "\\]") { flag=1; next }
+            /^## \[/ { flag=0 }
+            flag { print }
+          ' CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="See the assets to download and install this version."
+          fi
+          printf '%s\n' "$NOTES" > release-notes.md
+
+      - name: Create or reuse draft release
+        id: create
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # 用列表過濾而非 /releases/tags/{tag}：後者查不到 draft release。
+          find_id() {
+            gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+              --jq "[.[] | select(.tag_name==\"$RELEASE_TAG\")] | .[0].id // empty"
+          }
+
+          ID="$(find_id)"
+          if [ -n "$ID" ]; then
+            echo "Reusing existing release $ID for $RELEASE_TAG"
+          else
+            gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "SayIt v$RELEASE_VERSION" \
+              --notes-file release-notes.md \
+              --draft
+            ID="$(find_id)"
+          fi
+
+          if [ -z "$ID" ]; then
+            echo "Failed to resolve release id for $RELEASE_TAG" >&2
+            exit 1
+          fi
+          echo "release_id=$ID" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: create-release
     strategy:
       fail-fast: false
       matrix:
@@ -61,21 +137,7 @@ jobs:
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_ENV"
           echo "SENTRY_RELEASE=sayit@$RELEASE_VERSION" >> "$GITHUB_ENV"
           echo "VITE_SENTRY_RELEASE=sayit@$RELEASE_VERSION" >> "$GITHUB_ENV"
-
-          # Extract this version's section from CHANGELOG.md for the GitHub Release body
-          NOTES=$(awk -v ver="$RELEASE_VERSION" '
-            $0 ~ ("^## \\[" ver "\\]") { flag=1; next }
-            /^## \[/ { flag=0 }
-            flag { print }
-          ' CHANGELOG.md)
-          if [ -z "$NOTES" ]; then
-            NOTES="See the assets to download and install this version."
-          fi
-          {
-            echo "RELEASE_NOTES<<__SAYIT_NOTES_EOF__"
-            echo "$NOTES"
-            echo "__SAYIT_NOTES_EOF__"
-          } >> "$GITHUB_ENV"
+          # Release body 由 create-release job 從 CHANGELOG 產生，這裡不重複。
 
       - uses: actions/setup-node@v4
         with:
@@ -110,11 +172,9 @@ jobs:
           VITE_SENTRY_RELEASE: ${{ env.VITE_SENTRY_RELEASE }}
           VITE_SENTRY_SOURCEMAPS_ENABLED: ${{ matrix.upload_sourcemaps }}
         with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: "SayIt v${{ env.RELEASE_VERSION }}"
-          releaseBody: ${{ env.RELEASE_NOTES }}
-          releaseDraft: true
-          prerelease: false
+          # 指定既有 release，三個平台才會上傳到同一個（也才會正確合併 latest.json）。
+          # 不可改回 tagName + releaseDraft——那會讓每個 job 各自建 release。
+          releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}
 
       - name: Sentry release — sourcemaps, commits, deploy
@@ -169,23 +229,48 @@ jobs:
           gh release upload "$env:RELEASE_TAG" "${{ matrix.stable_name }}.sha256" --clobber
 
   publish-release:
-    needs: build
+    needs: [create-release, build]
     runs-on: ubuntu-24.04-arm
     steps:
-      - name: Resolve release metadata
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RAW_TAG="${{ inputs.tag }}"
-          else
-            RAW_TAG="${GITHUB_REF_NAME}"
-          fi
-
-          RAW_TAG="${RAW_TAG#refs/tags/}"
-          echo "RELEASE_TAG=$RAW_TAG" >> "$GITHUB_ENV"
-
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
+          # 用 release id 而非 tag：tag 查詢在有多個同 tag release 時會挑錯對象。
+          gh api -X PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/${{ needs.create-release.outputs.release_id }}" \
+            -F draft=false
+
+      - name: Verify release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ID="${{ needs.create-release.outputs.release_id }}"
+
+          # updater manifest 必須涵蓋全部三個平台。缺 darwin-aarch64 時
+          # Apple Silicon 使用者會靜默收不到更新，且不會有任何錯誤訊息。
+          PLATFORMS=$(gh api "repos/$GITHUB_REPOSITORY/releases/$ID/assets" \
+            --jq '.[] | select(.name=="latest.json") | .id' \
+            | xargs -I{} gh api "repos/$GITHUB_REPOSITORY/releases/assets/{}" \
+                -H "Accept: application/octet-stream" \
+            | jq -r '.platforms | keys[]')
+
+          echo "latest.json platforms:"
+          echo "$PLATFORMS"
+
+          for want in darwin-aarch64 darwin-x86_64 windows-x86_64; do
+            if ! echo "$PLATFORMS" | grep -qx "$want"; then
+              echo "::error::latest.json is missing platform '$want'" >&2
+              exit 1
+            fi
+          done
+
+          # 官網固定下載連結所指向的檔案
+          NAMES=$(gh api "repos/$GITHUB_REPOSITORY/releases/$ID/assets" --jq '.[].name')
+          for want in SayIt-mac-arm64.dmg SayIt-mac-x64.dmg SayIt-windows-x64.exe; do
+            if ! echo "$NAMES" | grep -qx "$want"; then
+              echo "::error::release is missing asset '$want'" >&2
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## 問題（v0.15.2 實際發生）

同一個 tag 產生了**兩個** GitHub Release（id `363808435` 與 `363808436`，`created_at` 完全相同）：

| release | draft | 資產 |
|---|---|---|
| 363808435 | false（已發佈） | 14 個 — 缺 ARM 的 updater 檔案 |
| 363808436 | **true（被遺棄）** | 4 個 — `SayIt_aarch64.app.tar.gz` / `.sig` / `SayIt_0.15.2_aarch64.dmg` / 自己的 `latest.json` |

結果正式 release 的 `latest.json` 只有 5 個 platform（v0.15.1 有 7 個），**缺 `darwin-aarch64`** → Apple Silicon 使用者靜默收不到自動更新，而且不會有任何錯誤訊息。

## 根因

三個 build job 各自呼叫 `tauri-apps/tauri-action@v0`，都帶 `releaseDraft: true` 且**沒有指定 `releaseId`**。tauri-action 的行為是「找同 tag 的 draft release，找不到就建一個」——三個 job 幾乎同時啟動時彼此都看不到，於是各建各的。

v0.15.1 沒中，只是因為 runner 排隊讓 job 啟動時間剛好錯開。這是隨機的競態，不是必然。

`publish-release` 用 `gh release edit "$RELEASE_TAG"` 依 tag 發佈，多個同 tag release 時只會命中其中一個，另一個永遠留在 draft。

## 修正

1. **新增前置 `create-release` job** — 建立（或沿用）唯一的 draft release 並輸出 `release_id`。
   查詢 id 用 `/releases` 列表過濾而非 `/releases/tags/{tag}`：**後者查不到 draft release**。
   沿用既有 release 的分支讓 workflow 重跑具有 idempotency。

2. **`build` 改為 `needs: create-release`，tauri-action 以 `releaseId` 上傳** —
   三個平台落在同一個 release，`latest.json` 才會被正確合併成 7 個 platform
   （這正是 v0.15.1 能有 7 個的原因）。

3. **release body 統一由 `create-release` 從 CHANGELOG 產生** — build job 不再重複那段 awk。

4. **`publish-release` 改用 release id 發佈** — tag 查詢在有多個同名 release 時會挑錯對象。

5. **`publish-release` 新增資產驗證** — 缺任何一項就讓 workflow 失敗，而不是發出一個半殘的 release：
   - `latest.json` 必須同時含 `darwin-aarch64` / `darwin-x86_64` / `windows-x86_64`
   - 官網固定下載連結的三個檔案（`SayIt-mac-arm64.dmg` / `SayIt-mac-x64.dmg` / `SayIt-windows-x64.exe`）都要存在

## v0.15.2 已就地修復

不等這個 PR。已將 draft 上的 3 個 ARM 資產搬到正式 release、合併兩份 `latest.json` 的 `platforms`（7/7 皆已驗證對應到實際存在且有簽章的資產）、刪除遺棄的 draft。目前 v0.15.2 有 17 個資產（與 v0.15.1 一致），`https://github.com/lettucebo/SayIt/releases/download/v0.15.2/SayIt_aarch64.app.tar.gz` 實測 HTTP 200。

## 驗證限制

`release.yml` 只有 push tag 才觸發，**這次改動無法在 merge 前端到端驗證**。已做的是：YAML 解析通過、job 相依與 `tauri-action` 參數經程式化檢查符合預期（`releaseId` 為該 action 的正式 input，用途是「upload artifacts as release assets」）。實際行為待下次發版驗證——而新增的資產驗證步驟正是為了讓「下次若再出問題」直接讓 workflow 失敗，而不是靜默發出半殘的 release。

依 fork 政策，本變更只保留在 `lettucebo/SayIt`，不送上游。
