### PR TITLE
fix(dashboard): distinguish MAI transcription usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 SayIt 版本更新紀錄。
 
+## [Unreleased]
+
+### Changed
+
+- 設定頁將 MAI-Transcribe 列為語音轉錄的首選項目，並標示品質最佳。
+
+### Fixed
+
+- 儀表板在使用 MAI-Transcribe 時會顯示正確服務名稱；其用量不再錯誤計入 Groq 的免費額度。
+
 ## [0.16.2] - 2026-08-10
 
 ### Fixed

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -91,7 +91,7 @@
     "model": {
       "title": "Model Selection",
       "description": "Choose the AI models for speech transcription and text enhancement. Faster models respond quicker, while larger models offer better quality.",
-      "whisperLabel": "Speech Transcription Model (Whisper)",
+      "whisperLabel": "Speech Transcription Model",
       "llmLabel": "Text Enhancement Model (LLM)",
       "whisperUpdated": "Speech transcription model updated",
       "geminiTranscriptionHint": "Gemini usually handles Chinese-English code-switching better than Whisper. Requires a Gemini API key.",
@@ -121,6 +121,7 @@
       "quotaPeriodMonthly": "Per month",
       "llmUpdated": "Text enhancement model updated",
       "default": "Default",
+      "bestQuality": "Best quality",
       "costPerHour": "${cost}/hour",
       "whisperDescription": {
         "largeV3": "Higher accuracy (10.3% WER); recommended for Chinese-English mixing. Also supports translation to English",
@@ -495,7 +496,7 @@
     "billedPlan": "Billed",
     "billedNoFreeQuota": "Pay-as-you-go — no free quota limit",
     "freeTierQuotaUnknown": "Free tier — limit not published; enter yours in Settings to see remaining",
-    "usageWhisper": "Whisper: {requests} req · {audio}",
+    "usageTranscription": "{provider}: {requests} req · {audio}",
     "usageGeminiTranscription": "Gemini transcription: {requests} req · {tokens} tokens",
     "quotaGeminiRequests": "Gemini transcription today {used} / {limit}",
     "quotaGeminiRequestsMonthly": "Gemini transcription this month {used} / {limit}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -91,7 +91,7 @@
     "model": {
       "title": "モデル選択",
       "description": "音声文字起こしとテキスト整理に使用する AI モデルを選択します。高速なモデルはより即時に応答し、大型モデルはより高品質です。",
-      "whisperLabel": "音声文字起こしモデル（Whisper）",
+      "whisperLabel": "音声文字起こしモデル",
       "llmLabel": "テキスト整理モデル（LLM）",
       "whisperUpdated": "音声文字起こしモデルが更新されました",
       "geminiTranscriptionHint": "Gemini は中国語と英語の混在音声で Whisper より高精度な場合が多く、Gemini API キーが必要です。",
@@ -121,6 +121,7 @@
       "quotaPeriodMonthly": "1か月あたり",
       "llmUpdated": "テキスト整理モデルが更新されました",
       "default": "デフォルト",
+      "bestQuality": "最高品質",
       "costPerHour": "1時間あたり ${cost}",
       "whisperDescription": {
         "largeV3": "精度が高く（WER 10.3%）、中国語と英語の混在にはこちらを推奨。英訳にも対応",
@@ -495,7 +496,7 @@
     "billedPlan": "従量課金",
     "billedNoFreeQuota": "従量課金 — 無料枠なし",
     "freeTierQuotaUnknown": "無料枠 — 上限は非公開です。設定に入力すると残量が表示されます",
-    "usageWhisper": "Whisper：{requests} 回 · {audio}",
+    "usageTranscription": "{provider}：{requests} 回 · {audio}",
     "usageGeminiTranscription": "Gemini 文字起こし：{requests} 回 · {tokens} tokens",
     "quotaGeminiRequests": "Gemini 文字起こし 本日 {used} / {limit} 回",
     "quotaGeminiRequestsMonthly": "Gemini 文字起こし 今月 {used} / {limit} 回",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -91,7 +91,7 @@
     "model": {
       "title": "모델 선택",
       "description": "음성 전사 및 텍스트 정리에 사용할 AI 모델을 선택하세요. 빠른 모델은 응답이 즉각적이고, 큰 모델은 품질이 더 좋습니다.",
-      "whisperLabel": "음성 전사 모델 (Whisper)",
+      "whisperLabel": "음성 전사 모델",
       "llmLabel": "텍스트 정리 모델 (LLM)",
       "whisperUpdated": "음성 전사 모델이 업데이트되었습니다",
       "geminiTranscriptionHint": "Gemini는 중국어-영어 혼용 음성에서 Whisper보다 정확한 경우가 많으며 Gemini API 키가 필요합니다.",
@@ -121,6 +121,7 @@
       "quotaPeriodMonthly": "한 달",
       "llmUpdated": "텍스트 정리 모델이 업데이트되었습니다",
       "default": "기본",
+      "bestQuality": "최고 품질",
       "costPerHour": "시간당 ${cost}",
       "whisperDescription": {
         "largeV3": "정확도가 높고(WER 10.3%) 중국어-영어 혼용에 권장됩니다. 영어 번역도 지원",
@@ -495,7 +496,7 @@
     "billedPlan": "유료",
     "billedNoFreeQuota": "유료 요금제 — 무료 할당량 없음",
     "freeTierQuotaUnknown": "무료 등급 — 한도가 비공개입니다. 설정에 입력하면 잔여량이 표시됩니다",
-    "usageWhisper": "Whisper: {requests}회 · {audio}",
+    "usageTranscription": "{provider}: {requests}회 · {audio}",
     "usageGeminiTranscription": "Gemini 전사: {requests}회 · {tokens} tokens",
     "quotaGeminiRequests": "Gemini 전사 오늘 {used} / {limit}회",
     "quotaGeminiRequestsMonthly": "Gemini 전사 이번 달 {used} / {limit}회",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -91,7 +91,7 @@
     "model": {
       "title": "模型选择",
       "description": "选择语音转录和文字整理使用的 AI 模型。速度较快的模型响应更即时，较大的模型品质更好。",
-      "whisperLabel": "语音转录模型（Whisper）",
+      "whisperLabel": "语音转录模型",
       "llmLabel": "文字整理模型（LLM）",
       "whisperUpdated": "语音转录模型已更新",
       "geminiTranscriptionHint": "Gemini 对中英夹杂的识别通常优于 Whisper，需要 Gemini API Key。",
@@ -121,6 +121,7 @@
       "quotaPeriodMonthly": "每月",
       "llmUpdated": "文字整理模型已更新",
       "default": "默认",
+      "bestQuality": "品质最佳",
       "costPerHour": "每小时 ${cost}",
       "whisperDescription": {
         "largeV3": "准确度较高（WER 10.3%），中英夹杂建议选这个；另支持翻译成英文",
@@ -495,7 +496,7 @@
     "billedPlan": "计费",
     "billedNoFreeQuota": "付费方案 — 无免费额度限制",
     "freeTierQuotaUnknown": "免费方案 — 额度未公开，可在设置填入以显示剩余量",
-    "usageWhisper": "Whisper：{requests} 次 · {audio}",
+    "usageTranscription": "{provider}：{requests} 次 · {audio}",
     "usageGeminiTranscription": "Gemini 转录：{requests} 次 · {tokens} tokens",
     "quotaGeminiRequests": "Gemini 转录今日 {used} / {limit} 次",
     "quotaGeminiRequestsMonthly": "Gemini 转录本月 {used} / {limit} 次",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -91,7 +91,7 @@
     "model": {
       "title": "模型選擇",
       "description": "選擇語音轉錄和文字整理使用的 AI 模型。速度較快的模型回應更即時，較大的模型品質更好。",
-      "whisperLabel": "語音轉錄模型（Whisper）",
+      "whisperLabel": "語音轉錄模型",
       "llmLabel": "文字整理模型（LLM）",
       "whisperUpdated": "語音轉錄模型已更新",
       "geminiTranscriptionHint": "Gemini 對中英夾雜的辨識通常優於 Whisper，需要 Gemini API Key。",
@@ -121,6 +121,7 @@
       "quotaPeriodMonthly": "每月",
       "llmUpdated": "文字整理模型已更新",
       "default": "預設",
+      "bestQuality": "品質最佳",
       "costPerHour": "每小時 ${cost}",
       "whisperDescription": {
         "largeV3": "準確度較高（WER 10.3%），中英夾雜建議選這個；另支援翻譯成英文",
@@ -495,7 +496,7 @@
     "billedPlan": "計費",
     "billedNoFreeQuota": "付費方案 — 無免費額度限制",
     "freeTierQuotaUnknown": "免費方案 — 額度未公開，可在設定填入以顯示剩餘量",
-    "usageWhisper": "Whisper：{requests} 次 · {audio}",
+    "usageTranscription": "{provider}：{requests} 次 · {audio}",
     "usageGeminiTranscription": "Gemini 轉錄：{requests} 次 · {tokens} tokens",
     "quotaGeminiRequests": "Gemini 轉錄今日 {used} / {limit} 次",
     "quotaGeminiRequestsMonthly": "Gemini 轉錄本月 {used} / {limit} 次",

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -315,6 +315,20 @@ export type WhisperModelId = "whisper-large-v3" | "whisper-large-v3-turbo";
 export type TranscriptionProviderId = "groq" | "azure" | "gemini" | "mai";
 
 /**
+ * 轉錄服務的使用者可見名稱。皆為專有名詞，五種介面語言共用。
+ * 使用 Record 讓新增 provider 時編譯器強制補齊顯示名稱。
+ */
+export const TRANSCRIPTION_PROVIDER_DISPLAY_NAME: Record<
+  TranscriptionProviderId,
+  string
+> = {
+  groq: "Groq Whisper",
+  azure: "Azure OpenAI Whisper",
+  gemini: "Gemini",
+  mai: "MAI-Transcribe",
+};
+
+/**
  * 免費額度的計算週期。多數 provider 是每日（如 Gemini 的 RPD、Groq 的 RPD），
  * 但也有「每月 N 次免費」的方案（例：Gemini 的 Google Search grounding 每月 5,000 次），
  * 因此額度模型必須同時支援兩種週期。

--- a/src/stores/useHistoryStore.ts
+++ b/src/stores/useHistoryStore.ts
@@ -148,13 +148,17 @@ const INSERT_API_USAGE_SQL = `
 const DAILY_QUOTA_USAGE_SQL = `
   SELECT
     api_type,
-    CASE WHEN model LIKE 'gemini-%' THEN 1 ELSE 0 END as is_gemini,
+    CASE
+      WHEN model LIKE 'gemini-%' THEN 'gemini'
+      WHEN model LIKE 'mai-%' THEN 'mai'
+      ELSE 'whisper'
+    END as provider_bucket,
     COUNT(*) as request_count,
     COALESCE(SUM(total_tokens), 0) as total_tokens,
     COALESCE(SUM(MAX(COALESCE(audio_duration_ms, 0), 10000)), 0) as billed_audio_ms
   FROM api_usage
   WHERE created_at >= $1 AND created_at < $2
-  GROUP BY api_type, is_gemini
+  GROUP BY api_type, provider_bucket
 `;
 
 const DAILY_USAGE_TREND_SQL = `
@@ -219,7 +223,7 @@ interface DashboardStatsRow {
 
 interface DailyQuotaUsageRow {
   api_type: string;
-  is_gemini: number;
+  provider_bucket: "gemini" | "mai" | "whisper";
   request_count: number;
   total_tokens: number;
   billed_audio_ms: number;
@@ -368,6 +372,8 @@ export const useHistoryStore = defineStore("history", () => {
   const EMPTY_QUOTA_USAGE: DailyQuotaUsage = {
     whisperRequestCount: 0,
     whisperBilledAudioMs: 0,
+    maiRequestCount: 0,
+    maiBilledAudioMs: 0,
     geminiTranscriptionRequestCount: 0,
     geminiTranscriptionTotalTokens: 0,
     llmRequestCount: 0,
@@ -445,6 +451,8 @@ export const useHistoryStore = defineStore("history", () => {
     const result: DailyQuotaUsage = {
       whisperRequestCount: 0,
       whisperBilledAudioMs: 0,
+      maiRequestCount: 0,
+      maiBilledAudioMs: 0,
       geminiTranscriptionRequestCount: 0,
       geminiTranscriptionTotalTokens: 0,
       llmRequestCount: 0,
@@ -453,17 +461,23 @@ export const useHistoryStore = defineStore("history", () => {
       vocabularyAnalysisTotalTokens: 0,
     };
 
-    // 每個 api_type 現在最多兩列（gemini / 非 gemini）→ 一律累加，不可覆寫
+    // 每個 api_type 依轉錄 provider 分桶；同一 bucket 仍可能有多筆，必須累加。
     for (const row of rows) {
-      const isGemini = row.is_gemini === 1;
       if (row.api_type === "whisper") {
-        if (isGemini) {
-          // Gemini 依 token 計量，音訊時長對它沒有計費意義
-          result.geminiTranscriptionRequestCount += row.request_count;
-          result.geminiTranscriptionTotalTokens += row.total_tokens;
-        } else {
-          result.whisperRequestCount += row.request_count;
-          result.whisperBilledAudioMs += row.billed_audio_ms;
+        switch (row.provider_bucket) {
+          case "gemini":
+            // Gemini 依 token 計量，音訊時長對它沒有計費意義
+            result.geminiTranscriptionRequestCount += row.request_count;
+            result.geminiTranscriptionTotalTokens += row.total_tokens;
+            break;
+          case "mai":
+            result.maiRequestCount += row.request_count;
+            result.maiBilledAudioMs += row.billed_audio_ms;
+            break;
+          case "whisper":
+            result.whisperRequestCount += row.request_count;
+            result.whisperBilledAudioMs += row.billed_audio_ms;
+            break;
         }
       } else if (row.api_type === "chat") {
         result.llmRequestCount += row.request_count;

--- a/src/types/transcription.ts
+++ b/src/types/transcription.ts
@@ -22,9 +22,13 @@ export interface TranscriptionRecord {
 }
 
 export interface DailyQuotaUsage {
-  /** Whisper 系轉錄（Groq/Azure，依音訊時長計費）——不含 Gemini */
+  /** Whisper 系轉錄（Groq/Azure，依音訊時長計費） */
   whisperRequestCount: number;
   whisperBilledAudioMs: number;
+  /** MAI-Transcribe（依音訊時長計費）——與 Whisper 系分開統計，
+   *  否則同一天混用會讓 Groq 的免費額度條計入 MAI 的請求數。 */
+  maiRequestCount: number;
+  maiBilledAudioMs: number;
   /** Gemini 轉錄（依 token 計量，音訊約 32 tokens/秒）——與 Whisper 分開統計，
    *  否則同一天混用會讓 Groq 的免費額度條計入 Gemini 的請求數。 */
   geminiTranscriptionRequestCount: number;

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -13,6 +13,7 @@ import {
   findLlmModelConfig,
   findWhisperModelConfig,
   getEffectiveGeminiTranscriptionRpd,
+  TRANSCRIPTION_PROVIDER_DISPLAY_NAME,
 } from "../lib/modelRegistry";
 import DashboardUsageChart from "../components/DashboardUsageChart.vue";
 import {
@@ -164,6 +165,26 @@ const quotaDimensionList = computed(() => {
 
 const hasFreeQuota = computed(() => quotaDimensionList.value.length > 0);
 
+const paidTranscriptionUsage = computed(() => {
+  const usage = historyStore.dashboardStats.dailyQuotaUsage;
+  switch (settingsStore.whisperProviderId) {
+    case "azure":
+      return {
+        provider: TRANSCRIPTION_PROVIDER_DISPLAY_NAME.azure,
+        requests: usage.whisperRequestCount,
+        audio: usage.whisperBilledAudioMs,
+      };
+    case "mai":
+      return {
+        provider: TRANSCRIPTION_PROVIDER_DISPLAY_NAME.mai,
+        requests: usage.maiRequestCount,
+        audio: usage.maiBilledAudioMs,
+      };
+    default:
+      return null;
+  }
+});
+
 // 計費方案（Azure/OpenAI/Anthropic）無免費額度，改顯示今日實際用量；
 // 額度不公開的 provider（Gemini）同樣改顯示用量，否則轉錄用量會完全不可見。
 const paidUsageList = computed(() => {
@@ -177,11 +198,12 @@ const paidUsageList = computed(() => {
         tokens: formatNumber(usage.geminiTranscriptionTotalTokens),
       }),
     });
-  } else if (isPaidWhisperProvider.value) {
+  } else if (paidTranscriptionUsage.value) {
     list.push({
-      label: t("dashboard.usageWhisper", {
-        requests: formatNumber(usage.whisperRequestCount),
-        audio: formatDurationFromMs(usage.whisperBilledAudioMs),
+      label: t("dashboard.usageTranscription", {
+        provider: paidTranscriptionUsage.value.provider,
+        requests: formatNumber(paidTranscriptionUsage.value.requests),
+        audio: formatDurationFromMs(paidTranscriptionUsage.value.audio),
       }),
     });
   }

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -2806,7 +2806,7 @@ onBeforeUnmount(() => {
           {{ $t("settings.model.description") }}
         </p>
 
-        <!-- Whisper 模型 -->
+        <!-- 語音轉錄模型 -->
         <div class="space-y-2">
           <Label for="whisper-model">{{ $t("settings.model.whisperLabel") }}</Label>
 
@@ -2817,6 +2817,20 @@ onBeforeUnmount(() => {
             :class="settingsStore.azureEnabled ? 'grid-cols-4' : 'grid-cols-2'"
             @update:model-value="(v: unknown) => handleWhisperProviderChange(v as TranscriptionProviderId)"
           >
+            <Label
+              v-if="settingsStore.azureEnabled"
+              for="whisper-provider-mai"
+              class="flex cursor-pointer items-center gap-2.5 rounded-md border border-border p-3 transition-colors"
+              :class="settingsStore.whisperProviderId === 'mai' ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'"
+            >
+              <RadioGroupItem id="whisper-provider-mai" value="mai" class="!size-0 !border-0 !shadow-none overflow-hidden" />
+              <div class="flex min-w-0 items-center gap-1.5">
+                <span class="text-sm font-medium">MAI-Transcribe</span>
+                <Badge variant="outline" class="shrink-0 px-1 py-0 text-[10px]">
+                  {{ $t("settings.model.bestQuality") }}
+                </Badge>
+              </div>
+            </Label>
             <Label
               for="whisper-provider-groq"
               class="flex cursor-pointer items-center gap-2.5 rounded-md border border-border p-3 transition-colors"
@@ -2841,15 +2855,6 @@ onBeforeUnmount(() => {
             >
               <RadioGroupItem id="whisper-provider-azure" value="azure" class="!size-0 !border-0 !shadow-none overflow-hidden" />
               <span class="text-sm font-medium">Azure OpenAI</span>
-            </Label>
-            <Label
-              v-if="settingsStore.azureEnabled"
-              for="whisper-provider-mai"
-              class="flex cursor-pointer items-center gap-2.5 rounded-md border border-border p-3 transition-colors"
-              :class="settingsStore.whisperProviderId === 'mai' ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'"
-            >
-              <RadioGroupItem id="whisper-provider-mai" value="mai" class="!size-0 !border-0 !shadow-none overflow-hidden" />
-              <span class="text-sm font-medium">MAI-Transcribe</span>
             </Label>
           </RadioGroup>
           <InlineFeedback :feedback="whisperProviderFeedback.state.value" class="block" />

--- a/tests/component/DashboardView.test.ts
+++ b/tests/component/DashboardView.test.ts
@@ -27,6 +27,8 @@ function makeHistory(usage: Record<string, number> = {}) {
   const quotaUsage = {
     whisperRequestCount: 0,
     whisperBilledAudioMs: 0,
+    maiRequestCount: 0,
+    maiBilledAudioMs: 0,
     geminiTranscriptionRequestCount: 0,
     geminiTranscriptionTotalTokens: 0,
     llmRequestCount: 0,
@@ -179,7 +181,7 @@ describe("DashboardView 額度卡片", () => {
 
     expect(text).toContain("今日用量");
     expect(text).toContain("計費");
-    expect(text).toContain("Whisper：12 次");
+    expect(text).toContain("Azure OpenAI Whisper：12 次");
     expect(text).toContain("LLM：8 次 · 4,500 tokens");
     expect(text).toContain("付費方案 — 無免費額度限制");
     expect(text).not.toContain("%");
@@ -225,9 +227,37 @@ describe("DashboardView 額度卡片", () => {
     expect(text).toContain("%");
     expect(text).toContain("計費");
     // 付費 Whisper 用量行（含實際次數）出現在卡片主體
-    expect(text).toContain("Whisper：7 次");
+    expect(text).toContain("Azure OpenAI Whisper：7 次");
     expect(text).not.toContain("付費方案 — 無免費額度限制");
     expect(text).not.toContain("Infinity");
+  });
+
+  it("[P0] MAI provider：用量標籤顯示 MAI-Transcribe 且使用 MAI 分桶", () => {
+    settingsState = makeSettings({
+      whisperProviderId: "mai",
+      selectedLlmProviderId: "azure",
+    });
+    historyState = makeHistory({
+      whisperRequestCount: 9,
+      maiRequestCount: 12,
+      maiBilledAudioMs: 60_000,
+    });
+    const text = mountDashboard().text();
+
+    expect(text).toContain("MAI-Transcribe：12 次 · 1 分鐘");
+    expect(text).not.toContain("MAI-Transcribe：9 次");
+  });
+
+  it("[P0] Groq 免費額度不計入 MAI 用量", () => {
+    settingsState = makeSettings();
+    historyState = makeHistory({
+      whisperRequestCount: 1000,
+      maiRequestCount: 5000,
+    });
+    const text = mountDashboard(true).text();
+
+    expect(text).toContain("50%");
+    expect(text).toMatch(/Whisper 1,?000\/2,?000 次/);
   });
 
   it("[P0] 混用 tooltip 仍保留付費用量與無額度提示", () => {

--- a/tests/unit/use-history-store.test.ts
+++ b/tests/unit/use-history-store.test.ts
@@ -473,6 +473,8 @@ describe("useHistoryStore", () => {
       expect(stats.dailyQuotaUsage).toEqual({
         whisperRequestCount: 0,
         whisperBilledAudioMs: 0,
+        maiRequestCount: 0,
+        maiBilledAudioMs: 0,
         geminiTranscriptionRequestCount: 0,
         geminiTranscriptionTotalTokens: 0,
         llmRequestCount: 0,
@@ -518,21 +520,28 @@ describe("useHistoryStore", () => {
       mockDbSelect.mockResolvedValueOnce([
         {
           api_type: "whisper",
-          is_gemini: 0,
+          provider_bucket: "whisper",
           request_count: 5,
           total_tokens: 0,
           billed_audio_ms: 50000,
         },
         {
           api_type: "whisper",
-          is_gemini: 1,
+          provider_bucket: "gemini",
           request_count: 2,
           total_tokens: 3840,
           billed_audio_ms: 20000,
         },
         {
+          api_type: "whisper",
+          provider_bucket: "mai",
+          request_count: 4,
+          total_tokens: 0,
+          billed_audio_ms: 40000,
+        },
+        {
           api_type: "chat",
-          is_gemini: 0,
+          provider_bucket: "whisper",
           request_count: 3,
           total_tokens: 1500,
           billed_audio_ms: 30000,
@@ -556,6 +565,8 @@ describe("useHistoryStore", () => {
       expect(stats.dailyQuotaUsage).toEqual({
         whisperRequestCount: 5,
         whisperBilledAudioMs: 50000,
+        maiRequestCount: 4,
+        maiBilledAudioMs: 40000,
         geminiTranscriptionRequestCount: 2,
         geminiTranscriptionTotalTokens: 3840,
         llmRequestCount: 3,
@@ -584,7 +595,7 @@ describe("useHistoryStore", () => {
       mockDbSelect.mockResolvedValueOnce([
         {
           api_type: "whisper",
-          is_gemini: 0,
+          provider_bucket: "whisper",
           request_count: 2,
           total_tokens: 0,
           billed_audio_ms: 20000,
@@ -643,6 +654,8 @@ describe("useHistoryStore", () => {
       expect(store.dashboardStats.dailyQuotaUsage).toEqual({
         whisperRequestCount: 0,
         whisperBilledAudioMs: 0,
+        maiRequestCount: 0,
+        maiBilledAudioMs: 0,
         geminiTranscriptionRequestCount: 0,
         geminiTranscriptionTotalTokens: 0,
         llmRequestCount: 0,


### PR DESCRIPTION
## 變更摘要

- 將 MAI-Transcribe 用量與 Whisper 系服務分開統計，避免扣減 Groq 免費額度。
- 儀表板依實際轉錄服務顯示名稱；MAI-Transcribe 不再顯示為 Whisper。
- 設定頁將 MAI-Transcribe 列為首選並標示品質最佳，不會自動改變既有 provider。
- 同步更新五種介面語言與 Changelog。