### PR TITLE
feat(guide): add release history access

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,6 +58,9 @@
     }
   },
   "plugins": {
+    "shell": {
+      "open": "https://.+"
+    },
     "updater": {
       "endpoints": [
         "https://github.com/lettucebo/SayIt/releases/latest/download/latest.json"

--- a/src/components/ExternalLink.vue
+++ b/src/components/ExternalLink.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { openExternalUrl } from "@/lib/externalLink";
+
+defineOptions({ inheritAttrs: false });
+
+const props = defineProps<{
+  href?: string;
+}>();
+
+function handleClick(event: MouseEvent) {
+  event.preventDefault();
+  void openExternalUrl(props.href);
+}
+
+function handleAuxClick(event: MouseEvent) {
+  if (event.button !== 1) return;
+  event.preventDefault();
+  void openExternalUrl(props.href);
+}
+</script>
+
+<template>
+  <a
+    v-if="href"
+    v-bind="$attrs"
+    :href="href"
+    target="_blank"
+    rel="noopener noreferrer"
+    @click="handleClick"
+    @auxclick="handleAuxClick"
+  >
+    <slot />
+  </a>
+  <span v-else v-bind="$attrs">
+    <slot />
+  </span>
+</template>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -700,7 +700,8 @@
   },
   "featureGuide": {
     "whatsNew": {
-      "title": "What's new in v{version}"
+      "title": "What's new in v{version}",
+      "allReleases": "View all releases"
     },
     "subtitle": "Here are all available features in SayIt to help you get started.",
     "voiceInput": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -700,7 +700,8 @@
   },
   "featureGuide": {
     "whatsNew": {
-      "title": "今回のアップデート内容（v{version}）"
+      "title": "今回のアップデート内容（v{version}）",
+      "allReleases": "すべてのリリースを見る"
     },
     "subtitle": "SayIt で利用できるすべての機能を紹介します。",
     "voiceInput": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -700,7 +700,8 @@
   },
   "featureGuide": {
     "whatsNew": {
-      "title": "이번 업데이트 내용 (v{version})"
+      "title": "이번 업데이트 내용 (v{version})",
+      "allReleases": "모든 릴리스 보기"
     },
     "subtitle": "SayIt에서 사용할 수 있는 모든 기능을 소개합니다.",
     "voiceInput": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -700,7 +700,8 @@
   },
   "featureGuide": {
     "whatsNew": {
-      "title": "本次更新亮点（v{version}）"
+      "title": "本次更新亮点（v{version}）",
+      "allReleases": "查看所有版本更新说明"
     },
     "subtitle": "以下是 SayIt 所有可用的操作功能，帮助你快速上手。",
     "voiceInput": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -700,7 +700,8 @@
   },
   "featureGuide": {
     "whatsNew": {
-      "title": "本次更新重點（v{version}）"
+      "title": "本次更新重點（v{version}）",
+      "allReleases": "查看所有版本更新說明"
     },
     "subtitle": "以下是 SayIt 所有可用的操作功能，幫助你快速上手。",
     "voiceInput": {

--- a/src/lib/externalLink.ts
+++ b/src/lib/externalLink.ts
@@ -1,0 +1,26 @@
+import { open } from "@tauri-apps/plugin-shell";
+import { extractErrorMessage } from "./errorUtils";
+import { captureError } from "./sentry";
+
+export async function openExternalUrl(
+  url: string | null | undefined,
+): Promise<boolean> {
+  if (!url) return false;
+
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== "https:") {
+      console.error(`[external-link] Blocked non-HTTPS URL: ${parsedUrl.protocol}`);
+      return false;
+    }
+
+    await open(parsedUrl.href);
+    return true;
+  } catch (error) {
+    console.error(
+      `[external-link] Failed to open URL: ${extractErrorMessage(error)}`,
+    );
+    captureError(error, { source: "external-link" });
+    return false;
+  }
+}

--- a/src/views/FeatureGuideView.vue
+++ b/src/views/FeatureGuideView.vue
@@ -9,13 +9,17 @@ import {
   BookOpen,
   History,
   Rocket,
+  ExternalLink as ExternalLinkIcon,
 } from "lucide-vue-next";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import ExternalLink from "@/components/ExternalLink.vue";
 import { useI18n } from "vue-i18n";
 import { computed, markRaw } from "vue";
 
 declare const __APP_VERSION__: string;
 const appVersion = __APP_VERSION__;
+const releasesUrl = "https://github.com/lettucebo/SayIt/releases";
 
 const { t, tm } = useI18n();
 
@@ -51,7 +55,7 @@ const featureList = [
 
 <template>
   <div class="p-6 space-y-4 text-foreground">
-    <Card v-if="whatsNewItems.length" data-testid="whats-new">
+    <Card data-testid="whats-new">
       <CardHeader class="border-b border-border py-3">
         <CardTitle class="text-base flex items-center gap-2">
           <Rocket class="size-4 text-muted-foreground" aria-hidden="true" />
@@ -60,12 +64,29 @@ const featureList = [
       </CardHeader>
       <CardContent class="pt-3 pb-4">
         <ol
+          v-if="whatsNewItems.length"
           class="space-y-3 text-sm text-muted-foreground leading-relaxed list-decimal list-outside pl-5"
         >
           <li v-for="(item, index) in whatsNewItems" :key="index">
             {{ item }}
           </li>
         </ol>
+        <div
+          :class="
+            whatsNewItems.length ? 'mt-3 border-t border-border pt-2' : ''
+          "
+        >
+          <Button as-child variant="link" class="h-auto p-0 text-muted-foreground">
+            <ExternalLink
+              :href="releasesUrl"
+              data-testid="all-releases-link"
+              class="gap-1.5 hover:text-primary"
+            >
+              {{ t("featureGuide.whatsNew.allReleases") }}
+              <ExternalLinkIcon class="size-3.5" aria-hidden="true" />
+            </ExternalLink>
+          </Button>
+        </div>
       </CardContent>
     </Card>
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -164,6 +164,7 @@ import { openLogFolder } from "../lib/logger";
 import type { AudioInputDeviceInfo } from "../types/audio";
 import { useAudioPreview } from "../composables/useAudioPreview";
 import ConnectionTestButton from "../components/ConnectionTestButton.vue";
+import ExternalLink from "../components/ExternalLink.vue";
 import InlineFeedback from "../components/InlineFeedback.vue";
 import SettingsActionRow from "../components/SettingsActionRow.vue";
 import SettingsControlRow from "../components/SettingsControlRow.vue";
@@ -2251,50 +2252,50 @@ onBeforeUnmount(() => {
         <div class="space-y-3">
           <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
             <span class="text-sm text-muted-foreground">{{ $t("settings.about.author") }}</span>
-            <a href="https://github.com/lettucebo" target="_blank" rel="noopener noreferrer" class="text-base font-semibold text-foreground hover:text-primary transition-colors">Money Yu</a>
+            <ExternalLink href="https://github.com/lettucebo" class="text-base font-semibold text-foreground hover:text-primary transition-colors">Money Yu</ExternalLink>
           </div>
 
           <div class="flex flex-wrap gap-x-4 gap-y-2">
-            <a href="https://github.com/lettucebo" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+            <ExternalLink href="https://github.com/lettucebo" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
               <Globe class="size-4" />
               <span>{{ $t("settings.about.website") }}</span>
-            </a>
-            <a href="https://www.facebook.com/lettucebo" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+            </ExternalLink>
+            <ExternalLink href="https://www.facebook.com/lettucebo" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
               <Facebook class="size-4" />
               <span>Facebook</span>
-            </a>
-            <a href="https://www.instagram.com/moneyyu816/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+            </ExternalLink>
+            <ExternalLink href="https://www.instagram.com/moneyyu816/" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
               <Instagram class="size-4" />
               <span>Instagram</span>
-            </a>
-            <a href="https://www.threads.com/@moneyyu816" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+            </ExternalLink>
+            <ExternalLink href="https://www.threads.com/@moneyyu816" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
               <AtSign class="size-4" />
               <span>Threads</span>
-            </a>
-            <a href="https://www.linkedin.com/in/abc12207/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+            </ExternalLink>
+            <ExternalLink href="https://www.linkedin.com/in/abc12207/" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
               <Linkedin class="size-4" />
               <span>LinkedIn</span>
-            </a>
+            </ExternalLink>
           </div>
         </div>
 
         <Separator />
 
         <div class="flex flex-wrap gap-x-4 gap-y-2">
-          <a href="https://github.com/lettucebo/SayIt" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+          <ExternalLink href="https://github.com/lettucebo/SayIt" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
             <Github class="size-4" />
             <span>{{ $t("settings.about.sourceCode") }}</span>
-          </a>
-          <a href="https://github.com/lettucebo/SayIt/issues" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
+          </ExternalLink>
+          <ExternalLink href="https://github.com/lettucebo/SayIt/issues" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors">
             <CircleAlert class="size-4" />
             <span>{{ $t("settings.about.reportIssue") }}</span>
-          </a>
+          </ExternalLink>
         </div>
 
         <!-- 原作者（不起眼小字 credit） -->
         <p class="text-xs text-muted-foreground/60">
           {{ $t("settings.about.originalAuthor") }}
-          <a href="https://jackle.pro" target="_blank" rel="noopener noreferrer" class="underline-offset-2 hover:text-muted-foreground hover:underline">Jackle Chen</a>
+          <ExternalLink href="https://jackle.pro" class="underline-offset-2 hover:text-muted-foreground hover:underline">Jackle Chen</ExternalLink>
         </p>
       </CardContent>
     </Card>
@@ -2462,14 +2463,12 @@ onBeforeUnmount(() => {
             {{ apiKeyStatusLabel }}
           </Badge>
         </div>
-        <a
+        <ExternalLink
           href="https://console.groq.com/keys"
-          target="_blank"
-          rel="noreferrer"
           class="text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           {{ $t("settings.apiKey.goToConsole") }} &rarr;
-        </a>
+        </ExternalLink>
       </CardHeader>
       <CardContent class="space-y-4">
         <p class="text-sm text-muted-foreground leading-relaxed">
@@ -2971,7 +2970,7 @@ onBeforeUnmount(() => {
             <p class="text-xs text-muted-foreground">
               {{ $t("settings.providerApiKey.geminiInstruction") }}
               ·
-              <a :href="findProviderConfig('gemini')?.consoleUrl" target="_blank" rel="noopener noreferrer" class="underline">{{ $t("settings.providerApiKey.goToGemini") }}</a>
+              <ExternalLink :href="findProviderConfig('gemini')?.consoleUrl" class="underline">{{ $t("settings.providerApiKey.goToGemini") }}</ExternalLink>
             </p>
             <ConnectionTestButton
               :on-test="testGeminiWhisperConnection"
@@ -3011,7 +3010,7 @@ onBeforeUnmount(() => {
             <p class="text-xs text-muted-foreground">
               {{ $t("settings.model.geminiQuotaHint") }}
               ·
-              <a href="https://aistudio.google.com/rate-limit" target="_blank" rel="noopener noreferrer" class="underline">{{ $t("settings.model.geminiQuotaLink") }}</a>
+              <ExternalLink href="https://aistudio.google.com/rate-limit" class="underline">{{ $t("settings.model.geminiQuotaLink") }}</ExternalLink>
             </p>
           </template>
 
@@ -3161,7 +3160,7 @@ onBeforeUnmount(() => {
           <p class="text-xs text-muted-foreground">
             {{ $t("settings.providerApiKey.openaiInstruction") }}
             ·
-            <a :href="findProviderConfig('openai')?.consoleUrl" target="_blank" rel="noopener noreferrer" class="underline">{{ $t("settings.providerApiKey.goToOpenai") }}</a>
+            <ExternalLink :href="findProviderConfig('openai')?.consoleUrl" class="underline">{{ $t("settings.providerApiKey.goToOpenai") }}</ExternalLink>
           </p>
         </div>
 
@@ -3199,7 +3198,7 @@ onBeforeUnmount(() => {
           <p class="text-xs text-muted-foreground">
             {{ $t("settings.providerApiKey.anthropicInstruction") }}
             ·
-            <a :href="findProviderConfig('anthropic')?.consoleUrl" target="_blank" rel="noopener noreferrer" class="underline">{{ $t("settings.providerApiKey.goToAnthropic") }}</a>
+            <ExternalLink :href="findProviderConfig('anthropic')?.consoleUrl" class="underline">{{ $t("settings.providerApiKey.goToAnthropic") }}</ExternalLink>
           </p>
         </div>
 
@@ -3237,7 +3236,7 @@ onBeforeUnmount(() => {
           <p class="text-xs text-muted-foreground">
             {{ $t("settings.providerApiKey.geminiInstruction") }}
             ·
-            <a :href="findProviderConfig('gemini')?.consoleUrl" target="_blank" rel="noopener noreferrer" class="underline">{{ $t("settings.providerApiKey.goToGemini") }}</a>
+            <ExternalLink :href="findProviderConfig('gemini')?.consoleUrl" class="underline">{{ $t("settings.providerApiKey.goToGemini") }}</ExternalLink>
           </p>
         </div>
 

--- a/tests/component/ExternalLink.test.ts
+++ b/tests/component/ExternalLink.test.ts
@@ -1,0 +1,84 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("../../src/lib/externalLink", () => ({
+  openExternalUrl: mocks.openExternalUrl,
+}));
+
+import ExternalLink from "../../src/components/ExternalLink.vue";
+
+describe("ExternalLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.openExternalUrl.mockResolvedValue(true);
+  });
+
+  it("[P1] 一般點擊應交由系統瀏覽器開啟", async () => {
+    const url = "https://github.com/lettucebo/SayIt";
+    const wrapper = mount(ExternalLink, {
+      props: { href: url },
+      slots: { default: "SayIt" },
+    });
+
+    await wrapper.get("a").trigger("click");
+
+    expect(mocks.openExternalUrl).toHaveBeenCalledWith(url);
+  });
+
+  it("[P1] 滑鼠中鍵應交由系統瀏覽器開啟", async () => {
+    const url = "https://github.com/lettucebo/SayIt/releases";
+    const wrapper = mount(ExternalLink, {
+      props: { href: url },
+    });
+
+    await wrapper.get("a").trigger("auxclick", { button: 1 });
+
+    expect(mocks.openExternalUrl).toHaveBeenCalledWith(url);
+  });
+
+  it("[P2] 滑鼠右鍵的 auxclick 不應開啟連結", async () => {
+    const wrapper = mount(ExternalLink, {
+      props: { href: "https://github.com/lettucebo/SayIt" },
+    });
+
+    await wrapper.get("a").trigger("auxclick", { button: 2 });
+
+    expect(mocks.openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("[P2] 應保留連結語意、屬性、樣式與 slot 內容", () => {
+    const url = "https://github.com/lettucebo/SayIt/issues";
+    const wrapper = mount(ExternalLink, {
+      props: { href: url },
+      attrs: {
+        class: "custom-link",
+        "data-testid": "external-link",
+      },
+      slots: { default: "<span>Report issue</span>" },
+    });
+    const anchor = wrapper.get("a");
+
+    expect(anchor.attributes("href")).toBe(url);
+    expect(anchor.attributes("target")).toBe("_blank");
+    expect(anchor.attributes("rel")).toBe("noopener noreferrer");
+    expect(anchor.classes()).toContain("custom-link");
+    expect(anchor.attributes("data-testid")).toBe("external-link");
+    expect(anchor.text()).toBe("Report issue");
+  });
+
+  it("[P1] href 未定義時不應渲染假的可點擊連結", () => {
+    const wrapper = mount(ExternalLink, {
+      attrs: { class: "unavailable-link" },
+      slots: { default: "Unavailable" },
+    });
+
+    expect(wrapper.find("a").exists()).toBe(false);
+    expect(wrapper.get("span").classes()).toContain("unavailable-link");
+    expect(wrapper.text()).toBe("Unavailable");
+    expect(mocks.openExternalUrl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/component/FeatureGuideView.test.ts
+++ b/tests/component/FeatureGuideView.test.ts
@@ -3,8 +3,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createI18n } from "vue-i18n";
 import { nextTick } from "vue";
 import zhTW from "../../src/i18n/locales/zh-TW.json";
+import zhCN from "../../src/i18n/locales/zh-CN.json";
 import en from "../../src/i18n/locales/en.json";
+import ja from "../../src/i18n/locales/ja.json";
+import ko from "../../src/i18n/locales/ko.json";
 import FeatureGuideView from "../../src/views/FeatureGuideView.vue";
+
+const mocks = vi.hoisted(() => ({
+  open: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: mocks.open,
+}));
 
 type Messages = Record<string, unknown>;
 
@@ -35,6 +46,8 @@ describe("FeatureGuideView 更新亮點卡片", () => {
   beforeEach(() => {
     // vitest 未套用 vite define，須手動注入 __APP_VERSION__，否則 mount 會 ReferenceError。
     vi.stubGlobal("__APP_VERSION__", "9.9.9");
+    mocks.open.mockReset();
+    mocks.open.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -90,6 +103,36 @@ describe("FeatureGuideView 更新亮點卡片", () => {
     expect(items).toEqual(canonicalItems(en));
   });
 
+  it("[P1] 應以真正的 anchor 開啟 fork 版本更新說明", async () => {
+    const wrapper = mount(FeatureGuideView, {
+      global: { plugins: [createTestI18n()] },
+    });
+    const link = wrapper.get('[data-testid="all-releases-link"]');
+
+    expect(link.attributes("href")).toBe(
+      "https://github.com/lettucebo/SayIt/releases",
+    );
+    expect(link.text()).toContain("查看所有版本更新說明");
+    expect(wrapper.findAll('[data-testid="whats-new"] button')).toHaveLength(0);
+
+    await link.trigger("click");
+
+    expect(mocks.open).toHaveBeenCalledWith(
+      "https://github.com/lettucebo/SayIt/releases",
+    );
+  });
+
+  it("[P1] 所有 5 個語系都應有非空的版本更新說明文案", () => {
+    const localeMessages = [zhTW, zhCN, en, ja, ko] as Messages[];
+
+    for (const messages of localeMessages) {
+      const featureGuide = messages.featureGuide as Record<string, unknown>;
+      const whatsNew = featureGuide.whatsNew as Record<string, unknown>;
+      expect(typeof whatsNew.allReleases).toBe("string");
+      expect((whatsNew.allReleases as string).trim().length).toBeGreaterThan(0);
+    }
+  });
+
   it("[P2] itemN key 非連續且亂序時應依數字順序渲染", () => {
     const messages = structuredClone(zhTW) as Messages;
     const mainApp = messages.mainApp as Record<string, unknown>;
@@ -114,7 +157,7 @@ describe("FeatureGuideView 更新亮點卡片", () => {
     expect(items).toEqual(["第一項", "第二項", "第十項"]);
   });
 
-  it("[P3] upgradeNotice 無任何 item 時應隱藏卡片", () => {
+  it("[P3] upgradeNotice 無任何 item 時仍應保留版本更新入口", () => {
     const noItems = structuredClone(zhTW) as Messages;
     const mainApp = noItems.mainApp as Record<string, unknown>;
     const notice = mainApp.upgradeNotice as Record<string, unknown>;
@@ -126,6 +169,10 @@ describe("FeatureGuideView 更新亮點卡片", () => {
       global: { plugins: [createTestI18n("zh-TW", { "zh-TW": noItems, en })] },
     });
 
-    expect(wrapper.find('[data-testid="whats-new"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="whats-new"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="whats-new"] ol').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="all-releases-link"]').exists()).toBe(
+      true,
+    );
   });
 });

--- a/tests/unit/external-link-policy.test.ts
+++ b/tests/unit/external-link-policy.test.ts
@@ -1,0 +1,33 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function findVueFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) return findVueFiles(path);
+    return entry.isFile() && entry.name.endsWith(".vue") ? [path] : [];
+  });
+}
+
+describe("外部連結政策", () => {
+  it("[P1] Vue 元件不應繞過 ExternalLink 使用外部 anchor", () => {
+    const componentPath = resolve(
+      process.cwd(),
+      "src/components/ExternalLink.vue",
+    );
+    const vueFiles = findVueFiles(resolve(process.cwd(), "src")).filter(
+      (path) => path !== componentPath,
+    );
+
+    for (const path of vueFiles) {
+      const source = readFileSync(path, "utf8");
+      expect(source, path).not.toMatch(
+        /<a\b[^>]*target\s*=\s*["']_blank["']/s,
+      );
+      expect(source, path).not.toMatch(
+        /<a\b[^>]*href\s*=\s*["']https?:\/\//s,
+      );
+    }
+  });
+});

--- a/tests/unit/external-link.test.ts
+++ b/tests/unit/external-link.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  open: vi.fn(),
+  captureError: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: mocks.open,
+}));
+
+vi.mock("../../src/lib/sentry", () => ({
+  captureError: mocks.captureError,
+}));
+
+import { openExternalUrl } from "../../src/lib/externalLink";
+
+describe("openExternalUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.open.mockResolvedValue(undefined);
+  });
+
+  it("[P1] 應使用系統預設瀏覽器開啟 HTTPS URL", async () => {
+    const result = await openExternalUrl(
+      "https://github.com/lettucebo/SayIt/releases",
+    );
+
+    expect(result).toBe(true);
+    expect(mocks.open).toHaveBeenCalledWith(
+      "https://github.com/lettucebo/SayIt/releases",
+    );
+  });
+
+  it.each([undefined, null, ""] as const)(
+    "[P2] 空 URL %s 應安全略過",
+    async (url) => {
+      await expect(openExternalUrl(url)).resolves.toBe(false);
+      expect(mocks.open).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "http://example.com",
+    "file:///tmp/test",
+    "javascript:alert(1)",
+    "mailto:user@example.com",
+  ])("[P1] 應拒絕非 HTTPS URL：%s", async (url) => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(openExternalUrl(url)).resolves.toBe(false);
+
+    expect(mocks.open).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("[P2] 格式錯誤的 URL 應回報並安全失敗", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(openExternalUrl("not a url")).resolves.toBe(false);
+
+    expect(mocks.open).not.toHaveBeenCalled();
+    expect(mocks.captureError).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+
+  it("[P1] Tauri 以純字串 reject 時應回報且不向呼叫端拋錯", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mocks.open.mockRejectedValue("shell scope denied");
+
+    await expect(
+      openExternalUrl("https://github.com/lettucebo/SayIt/releases"),
+    ).resolves.toBe(false);
+
+    expect(mocks.captureError).toHaveBeenCalledWith("shell scope denied", {
+      source: "external-link",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[external-link] Failed to open URL: shell scope denied",
+    );
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## 變更摘要

- 在「功能介紹」的本次更新重點卡片加入 fork GitHub Releases 入口
- 新增共用 `ExternalLink` 元件，以系統預設瀏覽器處理一般點擊與中鍵點擊
- 將設定頁 15 個既有外部連結改用共用元件
- 將 Tauri shell open scope 收斂為 HTTPS-only
- 新增五語系文案與外部連結政策、元件及服務測試

## 設計決策

- 連結只指向 `lettucebo/SayIt` 的 Releases，不導向其他來源
- 文案使用「查看所有版本更新說明」，避免宣稱 Releases 包含完整歷史
- 沿用既有 plugin-shell，將未來 opener 遷移隔離在共用服務內

Closing keyword: N/A（本變更無關聯 issue）
