### PR TITLE
feat(settings): add provider badges and Groq recommendation

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -59,3 +59,9 @@
 - **發現**：`tests/e2e/smoke.test.ts:12` 期待頁面標題符合 `/whisper/i`，但 baseline commit `39e5616` 的 `index.html:6` 已是 `<title>SayIt</title>`；完整 `pnpm test:e2e` 因此固定失敗。
 - **延後理由**：這是本次 UI 跑版修正前即存在的測試腐化，與模型選項、Tooltip 或響應式 grid 無關；依範圍規則不順手修改。
 - **後續切入點**：另案將 smoke assertion 改為正式且穩定的產品標題，再重跑完整 E2E suite。
+
+### 2. RadioGroup 的無障礙名稱不隨即時語系切換更新
+
+- **發現**：`reka-ui` 的 `Radio.vue` 以 computed 讀取 `[for=id]` Label 的 `innerText` 產生 `aria-label`，但 DOM 文字不是 Vue reactive dependency。設定頁不重新 mount 就切換語系時，可見文案會更新，radio 的無障礙名稱仍停在舊語言。既有 Foundry「品質最佳」Star 與 LLM provider 標記都受影響。
+- **延後理由**：本次需求是將 provider 的免費／推薦後綴改為 Badge / Star；改用 `aria-labelledby` 需重構三組 RadioGroup 的名稱組合與既有無障礙測試，超出本次視覺標記範圍。固定語系首次載入時的無障礙名稱仍正確。
+- **後續切入點**：為 provider 名稱、Badge 與 sr-only marker 配置穩定 ID，RadioGroupItem 改用可隨 DOM 文案更新的 `aria-labelledby` 組合，並新增 zh-TW → en 即時切換後的 E2E。

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -64,11 +64,11 @@
     },
     "provider": {
       "title": "LLM Provider",
-      "description": "Select the AI service for text enhancement and dictionary analysis. Groq and Gemini offer free quota, OpenAI and Anthropic are paid services.",
-      "groq": "Groq (Free)",
-      "openai": "OpenAI (Recommended)",
+      "description": "Select the AI service for text enhancement and dictionary analysis.",
+      "groq": "Groq",
+      "openai": "OpenAI",
       "anthropic": "Anthropic",
-      "gemini": "Google Gemini (Free Quota)",
+      "gemini": "Google Gemini",
       "groqNote": "Uses Groq API Key above",
       "azure": "Azure / Microsoft Foundry"
     },
@@ -123,6 +123,8 @@
       "llmUpdated": "Text enhancement model updated",
       "default": "Default",
       "bestQuality": "Best quality",
+      "freeBadge": "Free",
+      "recommended": "Recommended",
       "costPerHour": "${cost}/hour",
       "whisperDescription": {
         "largeV3": "Higher accuracy (10.3% WER); recommended for Chinese-English mixing. Also supports translation to English",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -64,11 +64,11 @@
     },
     "provider": {
       "title": "LLM プロバイダー",
-      "description": "テキスト整理と辞書分析に使用する AI サービスを選択します。Groq と Gemini は無料枠あり、OpenAI と Anthropic は有料です。",
-      "groq": "Groq（無料）",
-      "openai": "OpenAI（おすすめ）",
+      "description": "テキスト整理と辞書分析に使用する AI サービスを選択します。",
+      "groq": "Groq",
+      "openai": "OpenAI",
       "anthropic": "Anthropic",
-      "gemini": "Google Gemini（無料枠あり）",
+      "gemini": "Google Gemini",
       "groqNote": "上記の Groq API Key を使用",
       "azure": "Azure / Microsoft Foundry"
     },
@@ -123,6 +123,8 @@
       "llmUpdated": "テキスト整理モデルが更新されました",
       "default": "デフォルト",
       "bestQuality": "最高品質",
+      "freeBadge": "無料",
+      "recommended": "おすすめ",
       "costPerHour": "1時間あたり ${cost}",
       "whisperDescription": {
         "largeV3": "精度が高く（WER 10.3%）、中国語と英語の混在にはこちらを推奨。英訳にも対応",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -64,11 +64,11 @@
     },
     "provider": {
       "title": "LLM 제공업체",
-      "description": "텍스트 정리와 사전 분석에 사용할 AI 서비스를 선택하세요. Groq와 Gemini는 무료 할당량을 제공하며, OpenAI와 Anthropic는 유료입니다.",
-      "groq": "Groq (무료)",
-      "openai": "OpenAI (추천)",
+      "description": "텍스트 정리와 사전 분석에 사용할 AI 서비스를 선택하세요.",
+      "groq": "Groq",
+      "openai": "OpenAI",
       "anthropic": "Anthropic",
-      "gemini": "Google Gemini (무료 할당량)",
+      "gemini": "Google Gemini",
       "groqNote": "위의 Groq API Key 사용",
       "azure": "Azure / Microsoft Foundry"
     },
@@ -123,6 +123,8 @@
       "llmUpdated": "텍스트 정리 모델이 업데이트되었습니다",
       "default": "기본",
       "bestQuality": "최고 품질",
+      "freeBadge": "무료",
+      "recommended": "추천",
       "costPerHour": "시간당 ${cost}",
       "whisperDescription": {
         "largeV3": "정확도가 높고(WER 10.3%) 중국어-영어 혼용에 권장됩니다. 영어 번역도 지원",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -64,11 +64,11 @@
     },
     "provider": {
       "title": "LLM 模型服务",
-      "description": "选择文字整理和字典分析使用的 AI 服务。Groq 和 Gemini 提供免费额度，OpenAI 和 Anthropic 为付费服务。",
-      "groq": "Groq（免费）",
-      "openai": "OpenAI（推荐）",
+      "description": "选择文字整理和字典分析使用的 AI 服务。",
+      "groq": "Groq",
+      "openai": "OpenAI",
       "anthropic": "Anthropic",
-      "gemini": "Google Gemini（免费额度）",
+      "gemini": "Google Gemini",
       "groqNote": "使用上方 Groq API Key",
       "azure": "Azure / Microsoft Foundry"
     },
@@ -123,6 +123,8 @@
       "llmUpdated": "文字整理模型已更新",
       "default": "默认",
       "bestQuality": "品质最佳",
+      "freeBadge": "免费",
+      "recommended": "推荐",
       "costPerHour": "每小时 ${cost}",
       "whisperDescription": {
         "largeV3": "准确度较高（WER 10.3%），中英夹杂建议选这个；另支持翻译成英文",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -64,11 +64,11 @@
     },
     "provider": {
       "title": "LLM 模型服務",
-      "description": "選擇文字整理和字典分析使用的 AI 服務。Groq 和 Gemini 提供免費額度，OpenAI 和 Anthropic 為付費服務。",
-      "groq": "Groq（免費）",
-      "openai": "OpenAI（推薦）",
+      "description": "選擇文字整理和字典分析使用的 AI 服務。",
+      "groq": "Groq",
+      "openai": "OpenAI",
       "anthropic": "Anthropic",
-      "gemini": "Google Gemini（免費額度）",
+      "gemini": "Google Gemini",
       "groqNote": "使用上方 Groq API Key",
       "azure": "Azure / Microsoft Foundry"
     },
@@ -123,6 +123,8 @@
       "llmUpdated": "文字整理模型已更新",
       "default": "預設",
       "bestQuality": "品質最佳",
+      "freeBadge": "免費",
+      "recommended": "推薦",
       "costPerHour": "每小時 ${cost}",
       "whisperDescription": {
         "largeV3": "準確度較高（WER 10.3%），中英夾雜建議選這個；另支援翻譯成英文",

--- a/src/lib/llmProvider.ts
+++ b/src/lib/llmProvider.ts
@@ -17,6 +17,9 @@ export interface LlmProviderConfig {
   baseUrl: string;
   consoleUrl: string;
   apiKeyPrefix: string;
+  /** UI-level provider marker only; model-specific billing must be evaluated separately. */
+  hasFreeTier: boolean;
+  isRecommended?: boolean;
 }
 
 export const LLM_PROVIDER_LIST: LlmProviderConfig[] = [
@@ -26,6 +29,8 @@ export const LLM_PROVIDER_LIST: LlmProviderConfig[] = [
     baseUrl: "https://api.groq.com/openai/v1/chat/completions",
     consoleUrl: "https://console.groq.com/keys",
     apiKeyPrefix: "gsk_",
+    hasFreeTier: true,
+    isRecommended: true,
   },
   {
     id: "gemini",
@@ -33,6 +38,7 @@ export const LLM_PROVIDER_LIST: LlmProviderConfig[] = [
     baseUrl: "https://generativelanguage.googleapis.com/v1beta",
     consoleUrl: "https://aistudio.google.com/apikey",
     apiKeyPrefix: "AI",
+    hasFreeTier: true,
   },
   {
     id: "openai",
@@ -40,6 +46,7 @@ export const LLM_PROVIDER_LIST: LlmProviderConfig[] = [
     baseUrl: "https://api.openai.com/v1/chat/completions",
     consoleUrl: "https://platform.openai.com/api-keys",
     apiKeyPrefix: "sk-",
+    hasFreeTier: false,
   },
   {
     id: "anthropic",
@@ -47,6 +54,7 @@ export const LLM_PROVIDER_LIST: LlmProviderConfig[] = [
     baseUrl: "https://api.anthropic.com/v1/messages",
     consoleUrl: "https://console.anthropic.com/settings/keys",
     apiKeyPrefix: "sk-ant-",
+    hasFreeTier: false,
   },
   {
     id: "azure",
@@ -55,6 +63,7 @@ export const LLM_PROVIDER_LIST: LlmProviderConfig[] = [
     baseUrl: "",
     consoleUrl: "https://ai.azure.com/",
     apiKeyPrefix: "",
+    hasFreeTier: false,
   },
 ];
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -2869,7 +2869,17 @@ onBeforeUnmount(() => {
                 data-testid="whisper-provider-radio-groq"
                 class="!size-0 !border-0 !shadow-none overflow-hidden"
               />
-              <span class="min-w-0 text-sm font-medium">Groq</span>
+              <div class="flex min-w-0 items-center gap-1.5">
+                <span class="min-w-0 text-sm font-medium">Groq</span>
+                <Badge
+                  as="span"
+                  variant="secondary"
+                  data-testid="whisper-provider-free-badge-groq"
+                  class="shrink-0"
+                >
+                  {{ $t("settings.model.freeBadge") }}
+                </Badge>
+              </div>
             </Label>
             <Label
               for="whisper-provider-gemini"
@@ -2883,7 +2893,17 @@ onBeforeUnmount(() => {
                 data-testid="whisper-provider-radio-gemini"
                 class="!size-0 !border-0 !shadow-none overflow-hidden"
               />
-              <span class="min-w-0 text-sm font-medium">Gemini</span>
+              <div class="flex min-w-0 items-center gap-1.5">
+                <span class="min-w-0 text-sm font-medium">Gemini</span>
+                <Badge
+                  as="span"
+                  variant="secondary"
+                  data-testid="whisper-provider-free-badge-gemini"
+                  class="shrink-0"
+                >
+                  {{ $t("settings.model.freeBadge") }}
+                </Badge>
+              </div>
             </Label>
           </RadioGroup>
           <InlineFeedback :feedback="whisperProviderFeedback.state.value" class="block" />
@@ -3151,8 +3171,44 @@ onBeforeUnmount(() => {
               class="flex min-w-0 cursor-pointer items-center gap-2.5 rounded-md border border-border p-3 transition-colors"
               :class="settingsStore.selectedLlmProviderId === provider.id ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'"
             >
-              <RadioGroupItem :id="`provider-${provider.id}`" :value="provider.id" class="!size-0 !border-0 !shadow-none overflow-hidden" />
-              <span class="min-w-0 text-sm font-medium">{{ $t(`settings.provider.${provider.id}`) }}</span>
+              <RadioGroupItem
+                :id="`provider-${provider.id}`"
+                :value="provider.id"
+                :data-testid="`llm-provider-radio-${provider.id}`"
+                class="!size-0 !border-0 !shadow-none overflow-hidden"
+              />
+              <div class="flex min-w-0 items-center gap-1.5">
+                <span class="min-w-0 text-sm font-medium">{{ $t(`settings.provider.${provider.id}`) }}</span>
+                <Tooltip v-if="provider.isRecommended">
+                  <TooltipTrigger as-child>
+                    <span
+                      :data-testid="`llm-provider-recommended-${provider.id}`"
+                      class="inline-flex shrink-0 items-center text-primary"
+                    >
+                      <Star class="size-3.5 fill-current" aria-hidden="true" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent :data-testid="`llm-provider-recommended-${provider.id}-tooltip`">
+                    {{ $t("settings.model.recommended") }}
+                  </TooltipContent>
+                </Tooltip>
+                <span
+                  v-if="provider.isRecommended"
+                  :data-testid="`llm-provider-recommended-${provider.id}-text`"
+                  class="sr-only"
+                >
+                  {{ $t("settings.model.recommended") }}
+                </span>
+                <Badge
+                  v-if="provider.hasFreeTier"
+                  as="span"
+                  variant="secondary"
+                  :data-testid="`llm-provider-free-badge-${provider.id}`"
+                  class="shrink-0"
+                >
+                  {{ $t("settings.model.freeBadge") }}
+                </Badge>
+              </div>
             </Label>
           </RadioGroup>
           <InlineFeedback :feedback="llmProviderFeedback.state.value" class="block" />

--- a/tests/e2e/settings-layout.test.ts
+++ b/tests/e2e/settings-layout.test.ts
@@ -26,6 +26,18 @@ const LAYOUT_CASE_LIST = [
   { width: 1025, expectedColumns: 3 },
 ] as const;
 const LAYOUT_LOCALE_LIST = ["zh-TW", "en"] as const;
+const PROVIDER_MARKER_TEXT_BY_LOCALE = {
+  "zh-TW": {
+    free: "免費",
+    recommended: "推薦",
+    bestQuality: "品質最佳",
+  },
+  en: {
+    free: "Free",
+    recommended: "Recommended",
+    bestQuality: "Best quality",
+  },
+} as const;
 
 async function openSettings(
   page: Page,
@@ -33,6 +45,7 @@ async function openSettings(
     azureEnabled: boolean;
     locale?: (typeof LAYOUT_LOCALE_LIST)[number];
     width?: number;
+    llmProviderId?: "groq" | "openai" | "anthropic" | "gemini" | "azure";
   },
 ): Promise<void> {
   await page.setViewportSize({
@@ -43,6 +56,7 @@ async function openSettings(
     storeValues: {
       azureEnabled: options.azureEnabled,
       selectedLocale: options.locale ?? "zh-TW",
+      llmProviderId: options.llmProviderId,
     },
   });
   await page.goto(SETTINGS_URL, { waitUntil: "domcontentloaded" });
@@ -278,8 +292,100 @@ test.describe("Settings model selector layout", () => {
     );
     await expect(
       page.getByTestId("whisper-provider-radio-gemini"),
+    ).toHaveAttribute("data-state", "unchecked"    );
+  });
+
+  test("[P1] Groq 推薦 Star 可點選、可 hover 並只觸發一次 provider 切換", async ({
+    page,
+  }) => {
+    // Given: 明確從非 Groq provider 起始，否則點已選取的 radio 不會觸發變更
+    await openSettings(page, {
+      azureEnabled: true,
+      llmProviderId: "openai",
+      width: 769,
+    });
+
+    const groqOption = page.getByTestId("llm-provider-option-groq");
+    const groqRadio = page.getByTestId("llm-provider-radio-groq");
+    const star = page.getByTestId("llm-provider-recommended-groq");
+    const recommendedText =
+      PROVIDER_MARKER_TEXT_BY_LOCALE["zh-TW"].recommended;
+    await expect(groqRadio).toHaveAttribute("data-state", "unchecked");
+
+    // Then: 推薦 marker 只存在於 Groq，且不是沿用「品質最佳」文案
+    await expect(star).toHaveCount(1);
+    for (const providerId of ["openai", "anthropic", "gemini", "azure"]) {
+      await expect(
+        page.getByTestId(`llm-provider-recommended-${providerId}`),
+      ).toHaveCount(0);
+      await expect(
+        page.getByTestId(`llm-provider-radio-${providerId}`),
+      ).not.toHaveAccessibleName(new RegExp(escapeRegExp(recommendedText)));
+    }
+    await expect(
+      groqOption.getByTestId("llm-provider-recommended-groq-text"),
+    ).toHaveText(recommendedText);
+    await expect(groqRadio).toHaveAccessibleName(
+      new RegExp(escapeRegExp(recommendedText)),
+    );
+
+    // When: hover Star
+    await star.hover();
+
+    // Then: Tooltip 顯示「推薦」，而非 Foundry 的「品質最佳」
+    const tooltip = page.getByTestId(
+      "llm-provider-recommended-groq-tooltip",
+    );
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText(recommendedText);
+    await expect(tooltip).not.toContainText(
+      PROVIDER_MARKER_TEXT_BY_LOCALE["zh-TW"].bestQuality,
+    );
+
+    const writeCountBefore = await getStoreSetCount(page, "llmProviderId");
+
+    // When: 直接點擊 Star
+    await star.click();
+
+    // Then: Label 只觸發一次持久化，Groq 成為唯一選取項目
+    await expect
+      .poll(async () => getStoreSetCount(page, "llmProviderId"))
+      .toBe(writeCountBefore + 1);
+    await expect(groqRadio).toHaveAttribute("data-state", "checked");
+    await expect(
+      page.getByTestId("llm-provider-radio-openai"),
     ).toHaveAttribute("data-state", "unchecked");
   });
+
+  for (const locale of LAYOUT_LOCALE_LIST) {
+    test(`[P1] ${locale} 免費 Badge 只顯示於 Groq 與 Gemini`, async ({
+      page,
+    }) => {
+      // Given: Azure 啟用，兩組 provider 選項全部可見
+      await openSettings(page, { azureEnabled: true, locale, width: 769 });
+      const expectedText = PROVIDER_MARKER_TEXT_BY_LOCALE[locale].free;
+
+      // Then: LLM 與轉錄的 Groq / Gemini 都顯示該語系的免費 Badge
+      for (const testId of [
+        "llm-provider-free-badge-groq",
+        "llm-provider-free-badge-gemini",
+        "whisper-provider-free-badge-groq",
+        "whisper-provider-free-badge-gemini",
+      ]) {
+        await expect(page.getByTestId(testId)).toHaveText(expectedText);
+      }
+
+      // And: 付費 provider 與 Foundry 不得出現免費 Badge
+      for (const testId of [
+        "llm-provider-free-badge-openai",
+        "llm-provider-free-badge-anthropic",
+        "llm-provider-free-badge-azure",
+        "whisper-provider-free-badge-foundry",
+      ]) {
+        await expect(page.getByTestId(testId)).toHaveCount(0);
+      }
+    });
+  }
 
   test("[P1] Azure 停用時寬視窗維持兩欄且可切換", async ({ page }) => {
     // Given: Azure 停用且寬度已超過 lg 斷點

--- a/tests/unit/i18n-settings.test.ts
+++ b/tests/unit/i18n-settings.test.ts
@@ -398,6 +398,65 @@ describe("i18n 設定功能", () => {
   // ==========================================================================
 
   describe("翻譯檔 key 一致性", () => {
+    it("[P1] Provider 標記與簡化文案在 5 語系皆為精確值", async () => {
+      const zhTW = await import("../../src/i18n/locales/zh-TW.json");
+      const en = await import("../../src/i18n/locales/en.json");
+      const ja = await import("../../src/i18n/locales/ja.json");
+      const zhCN = await import("../../src/i18n/locales/zh-CN.json");
+      const ko = await import("../../src/i18n/locales/ko.json");
+      const localeMap = {
+        "zh-TW": {
+          messages: zhTW.default,
+          freeBadge: "免費",
+          recommended: "推薦",
+          description: "選擇文字整理和字典分析使用的 AI 服務。",
+        },
+        en: {
+          messages: en.default,
+          freeBadge: "Free",
+          recommended: "Recommended",
+          description:
+            "Select the AI service for text enhancement and dictionary analysis.",
+        },
+        ja: {
+          messages: ja.default,
+          freeBadge: "無料",
+          recommended: "おすすめ",
+          description:
+            "テキスト整理と辞書分析に使用する AI サービスを選択します。",
+        },
+        "zh-CN": {
+          messages: zhCN.default,
+          freeBadge: "免费",
+          recommended: "推荐",
+          description: "选择文字整理和字典分析使用的 AI 服务。",
+        },
+        ko: {
+          messages: ko.default,
+          freeBadge: "무료",
+          recommended: "추천",
+          description:
+            "텍스트 정리와 사전 분석에 사용할 AI 서비스를 선택하세요.",
+        },
+      };
+
+      for (const [
+        locale,
+        { messages, freeBadge, recommended, description },
+      ] of Object.entries(localeMap)) {
+        expect(messages.settings.model.freeBadge, locale).toBe(freeBadge);
+        expect(messages.settings.model.recommended, locale).toBe(recommended);
+        expect(messages.settings.provider.groq, locale).toBe("Groq");
+        expect(messages.settings.provider.openai, locale).toBe("OpenAI");
+        expect(messages.settings.provider.gemini, locale).toBe(
+          "Google Gemini",
+        );
+        expect(messages.settings.provider.description, locale).toBe(
+          description,
+        );
+      }
+    });
+
     it("[P0] Foundry 轉錄 UI 新增文案在 5 語系皆存在", async () => {
       const zhTW = await import("../../src/i18n/locales/zh-TW.json");
       const en = await import("../../src/i18n/locales/en.json");

--- a/tests/unit/llmProvider.test.ts
+++ b/tests/unit/llmProvider.test.ts
@@ -5,6 +5,7 @@ import {
   getProviderTimeout,
   findProviderConfig,
   getProviderIdForModel,
+  LLM_PROVIDER_LIST,
   type LlmChatRequest,
 } from "../../src/lib/llmProvider";
 
@@ -21,6 +22,24 @@ const BASE_REQUEST: LlmChatRequest = {
 };
 
 describe("llmProvider.ts", () => {
+  describe("LLM_PROVIDER_LIST", () => {
+    it("[P1] 免費層只標記 Groq 與 Gemini", () => {
+      expect(
+        LLM_PROVIDER_LIST.filter((provider) => provider.hasFreeTier).map(
+          (provider) => provider.id,
+        ),
+      ).toEqual(["groq", "gemini"]);
+    });
+
+    it("[P1] 推薦服務只標記 Groq", () => {
+      expect(
+        LLM_PROVIDER_LIST.filter((provider) => provider.isRecommended).map(
+          (provider) => provider.id,
+        ),
+      ).toEqual(["groq"]);
+    });
+  });
+
   // ==========================================================================
   // buildFetchParams
   // ==========================================================================


### PR DESCRIPTION
## 變更摘要

- 將 LLM provider 名稱中的免費／推薦文字後綴改為結構化視覺標記
- Groq 與 Gemini 在 LLM、語音轉錄兩區塊顯示本地化免費 Badge
- 將推薦 Star 移至 Groq，並保留 Tooltip 與螢幕閱讀器文字
- 五語系 provider 名稱改回純名稱，簡化重複的免費／付費說明
- 補強 provider metadata、i18n、互動與響應式版面回歸測試

## 設計決策

- 付費 provider 不加標記，降低視覺噪音
- Badge 使用 `as="span"`，維持 Label 內有效的 HTML 內容模型
- provider 免費層 metadata 僅供設定 UI 呈現，不改動 Dashboard 計費判斷