### PR TITLE
fix(autostart): keep debug builds from hijacking release autostart

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,6 +122,7 @@ CI（`.github/workflows/ci.yml`）：Ubuntu 跑 `vue-tsc --noEmit` → `eslint s
 | `get_hud_target_position` | `lib.rs` | useVoiceFlowStore | `app: AppHandle` | `Result<HudTargetPosition, String>`（含 `space: "physical"\|"logical"`，Windows 回 physical 以避開 tao 跨 DPI 錯位） |
 | `set_hud_visibility` | `plugins/hud_window.rs` | App.vue、useVoiceFlowStore | `app: AppHandle, visible: bool, click_through: bool` | `Result<(), String>`（同步 command；集中 show/hide + click-through。Windows 額外恢復最小化、重宣告 topmost/toolwindow/noactivate，並在原生 style 變更後重套 DWM blur，避免透明背景退化為黑色；非 Windows 維持 Tauri 視窗行為） |
 | `get_os_theme` | `lib.rs` | theme.ts（`refreshOsTheme`） | — | `Option<String>`（`"dark"` / `"light"`；Windows 讀登錄檔為權威來源，非 Windows／讀取失敗回 `null` 讓前端 fallback 到 `window.theme()` → `matchMedia`） |
+| `is_debug_build` | `lib.rs` | useSettingsStore（`initializeAutoStart`） | — | `bool`（`cfg!(debug_assertions)`；debug 建置據此跳過「首次啟動自動註冊開機自啟動」，避免搶走正式版共用的 `Run\SayIt` 登錄值） |
 | `set_file_logging_enabled` | `plugins/logging.rs` | useSettingsStore, logger.ts | `enabled: bool` | `()` |
 | `open_log_folder` | `plugins/logging.rs` | logger.ts（SettingsView） | — | `Result<(), String>` |
 | `cleanup_old_logs` | `plugins/logging.rs` | main-window.ts | `days: u32, app: AppHandle` | `Result<Vec<String>, String>` |

--- a/docs/api-contracts-backend.md
+++ b/docs/api-contracts-backend.md
@@ -10,7 +10,7 @@
 
 | 軌道                       | 數量    | 來源                                                                        |
 | -------------------------- | ------- | --------------------------------------------------------------------------- |
-| Tauri Commands             | **51**  | `lib.rs::run()` 的 `generate_handler!` macro                                |
+| Tauri Commands             | **52**  | `lib.rs::run()` 的 `generate_handler!` macro                                |
 | Rust → Frontend Events     | **13**  | Rust 端 `emit()` 的事件名（前端常數在 `useTauriEvents.ts`）                 |
 | Frontend-only Events       | **9**   | `src/composables/useTauriEvents.ts`                                         |
 
@@ -26,7 +26,7 @@
 > - 下方 `invoke(...)` 範例中的參數是**前端實際要傳的鍵名**，一律 **camelCase**（Tauri 會轉成 Rust 的 snake_case）。例如 Rust 的 `api_key` / `file_path` / `restore_clipboard`，前端要寫 `apiKey` / `filePath` / `restoreClipboard`。
 > - Rust 簽章中的 `app: AppHandle`、`state: State<T>` 由 **Tauri 自動注入**，呼叫端**不要傳**。表格中的「簽名」欄列的是 Rust 端簽章（含注入參數），`invoke(...)` 範例則只列呼叫端該傳的東西。
 
-### 2.1 系統與生命週期（7 個）
+### 2.1 系統與生命週期（8 個）
 
 #### `set_file_logging_enabled`
 ```ts
@@ -85,6 +85,15 @@ invoke('get_os_theme') → 'dark' | 'light' | null
 ```
 - **Rust 位置**：`lib.rs`
 - **用途**：查詢權威的 OS 外觀。Windows 讀登錄檔（透明且隱藏的 HUD 其 WebView2 拿不到正確值），非 Windows 或讀取失敗回 `null`，前端 fallback 到 `window.theme()` → `matchMedia`。
+
+#### `is_debug_build`
+```ts
+invoke('is_debug_build') → boolean
+```
+- **Rust 位置**：`lib.rs`（`cfg!(debug_assertions)`）
+- **呼叫端**：`useSettingsStore.initializeAutoStart()`
+- **用途**：讓前端判斷是否為 debug 建置，藉此**跳過「首次啟動自動註冊開機自啟動」**。autostart 的登錄值名稱取自 productName、與 identifier 無關，所有建置共用同一把（Windows 為 `HKCU\...\Run\SayIt`）；debug 建置若自動註冊，會把開機自啟動指向帶 console 的開發執行檔並蓋掉正式版。
+- **為何不用前端判斷**：`tauri build --debug` 的前端是 production bundle（`import.meta.env.DEV` 為 false），但 Rust 仍是 debug。此 command 與 `main.rs` 決定是否隱藏 console 的條件同源。
 
 ### 2.2 熱鍵（8 個 · `plugins/hotkey_listener.rs`，`update_hotkey_config` 在 `lib.rs`）
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -327,3 +327,5 @@ sqlite3 %APPDATA%\com.sayit.app\app.db
 | 加 Rust Command 忘記在 `invoke_handler!` 註冊                          | Rust 編譯通過但前端 `invoke()` 會 timeout 或回 "command not found"                  |
 | Cmd+V 在 Fn 按住期間執行 → 輸入 "c" 字元                                | 已知 issue #25，避開即可                                                            |
 | 開兩個 dev session（兩個 .app） → 全域熱鍵廣播                          | v0.9.5 已導入 `tauri-plugin-single-instance` 防止                                   |
+| 開機自動啟動跑到 debug 建置、每次登入冒出 console 黑視窗                | autostart 登錄值名稱取自 productName、**與 identifier 無關**（Windows 為 `HKCU\...\Run\SayIt`），任何建置呼叫 `enable()` 都會覆寫同一把。現由 `is_debug_build` 擋掉 debug 的首次自動註冊，且 debug 改用獨立名稱 `SayIt (dev)`；若已被搶走，手動把該值改回正式版路徑 |
+| 改 identifier 做診斷建置後，行為與正式版不一致                          | 換 identifier 會得到**獨立的** store／SQLite／single-instance 鎖，等同全新安裝（會被視為「首次啟動」），且能與正式版同時執行；診斷完記得清掉 `%APPDATA%\<identifier>` 與殘留的自啟動登錄值 |

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -146,6 +146,20 @@ fn get_os_theme() -> Option<String> {
     current_os_theme_is_dark().map(|dark| if dark { "dark" } else { "light" }.to_string())
 }
 
+/// 供前端判斷目前執行的是否為 debug 建置。
+///
+/// 這與「有沒有 console 視窗」同源：`main.rs` 的
+/// `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]` 只在 release
+/// 隱藏 console，因此 debug 建置一定帶 console。前端據此跳過「首次啟動自動註冊開機
+/// 自啟動」，避免把自啟動指向帶 console 的開發執行檔（見 `useSettingsStore`）。
+///
+/// 不能只靠前端的 `import.meta.env.DEV` 判斷：`tauri build --debug` 的前端是
+/// production bundle（`DEV` 為 false），但 Rust 仍是 debug。
+#[command]
+fn is_debug_build() -> bool {
+    cfg!(debug_assertions)
+}
+
 /// HUD 視窗邏輯寬度（pixels），對應前端 CSS 470px
 const HUD_WINDOW_WIDTH_LOGICAL: f64 = 470.0;
 
@@ -502,10 +516,27 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_store::Builder::default().build())
-        .plugin(tauri_plugin_autostart::init(
-            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-            None,
-        ))
+        .plugin({
+            // autostart 的登錄值名稱取自 productName（Windows 為 `HKCU\...\Run\SayIt`），
+            // 與 identifier 無關 —— 任何 SayIt 建置呼叫 enable() 都會覆寫同一把值。
+            // 曾因此讓診斷用 debug 建置搶走正式版的開機自啟動，導致每次開機跑到帶
+            // console 的開發執行檔。debug 建置改用獨立名稱，release 維持預設值以保持
+            // 既有使用者的登錄項不變。
+            //
+            // 結構刻意對齊 plugin 的 `init()`：`macos_launcher` 只存在於 macOS。
+            #[allow(unused_mut)]
+            let mut builder = tauri_plugin_autostart::Builder::new();
+            #[cfg(target_os = "macos")]
+            {
+                builder =
+                    builder.macos_launcher(tauri_plugin_autostart::MacosLauncher::LaunchAgent);
+            }
+            #[cfg(debug_assertions)]
+            {
+                builder = builder.app_name("SayIt (dev)");
+            }
+            builder.build()
+        })
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
@@ -519,6 +550,7 @@ pub fn run() {
             get_hud_target_position,
             plugins::hud_window::set_hud_visibility,
             get_os_theme,
+            is_debug_build,
             plugins::audio_control::mute_system_audio,
             plugins::audio_control::restore_system_audio,
             plugins::clipboard_paste::capture_target_window,

--- a/src/stores/useSettingsStore.ts
+++ b/src/stores/useSettingsStore.ts
@@ -3218,12 +3218,43 @@ export const useSettingsStore = defineStore("settings", () => {
     }
   }
 
+  /**
+   * 目前執行的是否為 debug 建置（Rust `cfg!(debug_assertions)`）。
+   *
+   * 查詢失敗時保守回 true：寧可不自動註冊開機自啟動（使用者仍可手動開啟），
+   * 也不要誤把自啟動指向帶 console 的開發執行檔。
+   */
+  async function isDebugBuild(): Promise<boolean> {
+    try {
+      return await invoke<boolean>("is_debug_build");
+    } catch (err) {
+      console.warn(
+        "[useSettingsStore] is_debug_build failed; assuming debug build:",
+        extractErrorMessage(err),
+      );
+      return true;
+    }
+  }
+
   async function initializeAutoStart() {
     try {
       const store = await load(STORE_NAME);
       const hasInitAutoStart = await store.get<boolean>("hasInitAutoStart");
 
       if (!hasInitAutoStart) {
+        // autostart 的登錄值名稱取自 productName，與 identifier 無關，所有建置共用
+        // 同一把（Windows 為 `HKCU\...\Run\SayIt`）。debug 建置若在這裡自動註冊，
+        // 會把開機自啟動指向帶 console 的開發執行檔、蓋掉正式版。
+        // 因此 debug 只讀狀態、不自動註冊，也刻意不寫入 hasInitAutoStart，
+        // 讓正式版之後仍能正常完成首次註冊；使用者仍可從設定頁手動開關。
+        if (await isDebugBuild()) {
+          await loadAutoStartStatus();
+          console.log(
+            "[useSettingsStore] Debug build: skipped first-launch auto-start registration",
+          );
+          return;
+        }
+
         const { enable } = await import("@tauri-apps/plugin-autostart");
         await enable();
         await store.set("hasInitAutoStart", true);

--- a/tests/unit/use-settings-store-autostart.test.ts
+++ b/tests/unit/use-settings-store-autostart.test.ts
@@ -25,8 +25,10 @@ vi.mock("@tauri-apps/plugin-store", () => ({
   }),
 }));
 
+const mockInvoke = vi.fn();
+
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn().mockResolvedValue(undefined),
+  invoke: mockInvoke,
 }));
 
 vi.mock("../../src/composables/useTauriEvents", () => ({
@@ -43,6 +45,11 @@ describe("useSettingsStore — 自啟動功能", () => {
     mockStoreGet.mockReset();
     mockStoreSet.mockReset();
     mockStoreSave.mockReset();
+    mockInvoke.mockReset();
+    // 預設模擬 release 建置：`is_debug_build` 回 false，其餘 command 回 undefined。
+    mockInvoke.mockImplementation(async (command: string) =>
+      command === "is_debug_build" ? false : undefined,
+    );
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -176,6 +183,50 @@ describe("useSettingsStore — 自啟動功能", () => {
       expect(mockEnable).not.toHaveBeenCalled();
       expect(mockIsEnabled).toHaveBeenCalledOnce();
       expect(store.isAutoStartEnabled).toBe(true);
+    });
+
+    // autostart 登錄值名稱取自 productName、與 identifier 無關，所有建置共用同一把；
+    // debug 建置若自動註冊，會把開機自啟動指向帶 console 的開發執行檔並蓋掉正式版。
+    it("[P0] debug 建置首次啟動不應自動註冊，且不寫入 hasInitAutoStart", async () => {
+      mockStoreGet.mockImplementation(async (key: string) => {
+        if (key === "hasInitAutoStart") return null;
+        return null;
+      });
+      mockInvoke.mockImplementation(async (command: string) =>
+        command === "is_debug_build" ? true : undefined,
+      );
+      mockIsEnabled.mockResolvedValue(false);
+
+      const { useSettingsStore } = await import(
+        "../../src/stores/useSettingsStore"
+      );
+      const store = useSettingsStore();
+      await store.initializeAutoStart();
+
+      expect(mockEnable).not.toHaveBeenCalled();
+      expect(mockStoreSet).not.toHaveBeenCalledWith("hasInitAutoStart", true);
+      expect(mockIsEnabled).toHaveBeenCalledOnce();
+      expect(store.isAutoStartEnabled).toBe(false);
+    });
+
+    it("[P1] 無法判斷建置型別時應保守跳過自動註冊", async () => {
+      mockStoreGet.mockImplementation(async (key: string) => {
+        if (key === "hasInitAutoStart") return null;
+        return null;
+      });
+      mockInvoke.mockRejectedValue(new Error("command not found"));
+      mockIsEnabled.mockResolvedValue(false);
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { useSettingsStore } = await import(
+        "../../src/stores/useSettingsStore"
+      );
+      const store = useSettingsStore();
+      await store.initializeAutoStart();
+
+      expect(mockEnable).not.toHaveBeenCalled();
+      expect(mockStoreSet).not.toHaveBeenCalledWith("hasInitAutoStart", true);
+      expect(console.warn).toHaveBeenCalled();
     });
 
     it("[P0] 初始化失敗應靜默處理", async () => {


### PR DESCRIPTION
## 問題

Windows 每次登入都會冒出一個 console 黑視窗。

根因是 **autostart 的登錄值名稱取自 productName，與 app identifier 無關** —— 所有 SayIt 建置共用同一把 `HKCU\Software\Microsoft\Windows\CurrentVersion\Run\SayIt`。而 `initializeAutoStart()` 是依「各 identifier 自己的 store 內 `hasInitAutoStart`」判斷是否首次啟動，因此換了 identifier 的診斷用 debug 建置會被當成全新安裝，呼叫 `enable()` 覆寫該登錄值，把開機自啟動指向 debug 執行檔。

debug 建置沒有 `main.rs` 的 `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]`，一定帶 console，於是每次開機就出現黑視窗；而且開機啟動到的是開發版而非正式版。

## 變更

1. **新增 `is_debug_build` command**（`src-tauri/src/lib.rs`，回傳 `cfg!(debug_assertions)`）。`initializeAutoStart()` 據此在 debug 建置跳過首次自動註冊，並**刻意不寫入 `hasInitAutoStart`**，讓正式版之後仍能正常完成首次註冊。查詢失敗時保守視為 debug（寧可不註冊）。
2. **autostart plugin 改用 `Builder`**，debug 建置使用獨立名稱 `SayIt (dev)`；release 維持預設名稱，確保既有使用者的登錄項不變。
3. 同步 IPC 契約表、`docs/api-contracts-backend.md`（Commands 51→52）與開發文件的陷阱說明。

## 關鍵決策

- **用 Rust `cfg!(debug_assertions)` 而非前端 `import.meta.env.DEV`**：`tauri build --debug` 的前端是 production bundle（`DEV` 為 false）但 Rust 仍是 debug，前端判斷會漏掉。此 command 與「是否隱藏 console」同源。
- **release 名稱不變**：若改成隨 identifier 命名，既有使用者升級後會留下孤兒 `SayIt` 登錄項，因此只在 debug 端改名。
- **雙層防護**：跳過自動註冊擋掉「無聲污染」，獨立名稱再擋掉「開發時手動 toggle 或匯入設定」的路徑。